### PR TITLE
Fixes wrapped types definition

### DIFF
--- a/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
@@ -245,14 +245,14 @@ class StarWarsIntrospectionTests : XCTestCase {
                             "name": "appearsIn",
                             "type": [
                                 "name": nil,
-                                "kind": "LIST",
+                                "kind": "NON_NULL",
                             ],
                         ],
                         [
                             "name": "friends",
                             "type": [
                                 "name": nil,
-                                "kind": "LIST",
+                                "kind": "NON_NULL",
                             ],
                         ],
                         [
@@ -319,9 +319,9 @@ class StarWarsIntrospectionTests : XCTestCase {
                             "name": "appearsIn",
                             "type": [
                                 "name": nil,
-                                "kind": "LIST",
+                                "kind": "NON_NULL",
                                 "ofType": [
-                                    "kind": "NON_NULL",
+                                    "kind": "LIST",
                                     "name": nil
                                 ]
                             ],
@@ -330,9 +330,9 @@ class StarWarsIntrospectionTests : XCTestCase {
                             "name": "friends",
                             "type": [
                                 "name": nil,
-                                "kind": "LIST",
+                                "kind": "NON_NULL",
                                 "ofType": [
-                                    "kind": "NON_NULL",
+                                    "kind": "LIST",
                                     "name": nil
                                 ]
                             ],

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsSchema.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsSchema.swift
@@ -41,16 +41,16 @@ extension Planet: OutputType {}
  *     interface Character {
  *         id: String!
  *         name: String!
- *         friends: [Character!]
- *         appearsIn: [Episode!]
+ *         friends: [Character!]!
+ *         appearsIn: [Episode!]!
  *         secretBackstory: String
  *     }
  *
  *     type Human : Character {
  *         id: String!
  *         name: String!
- *         friends: [Character!]
- *         appearsIn: [Episode!]
+ *         friends: [Character!]!
+ *         appearsIn: [Episode!]!
  *         secretBackstory: String
  *         homePlanet: String!
  *     }
@@ -58,8 +58,8 @@ extension Planet: OutputType {}
  *     type Droid : Character {
  *         id: String!
  *         name: String!
- *         friends: [Character!]
- *         appearsIn: [Episode!]
+ *         friends: [Character!]!
+ *         appearsIn: [Episode!]!
  *         secretBackstory: String
  *         primaryFunction: String!
  *     }
@@ -111,8 +111,8 @@ let starWarsSchema = try! Schema<NoRoot, NoContext> { schema in
      *     interface Character {
      *         id: String!
      *         name: String!
-     *         friends: [Character!]
-     *         appearsIn: [Episode!]
+     *         friends: [Character!]!
+     *         appearsIn: [Episode!]!
      *         secretBackstory: String
      *     }
      */
@@ -161,7 +161,7 @@ let starWarsSchema = try! Schema<NoRoot, NoContext> { schema in
      *         diameter: Int!
      *         rotationPeriod: Int!
      *         orbitalPeriod: Int!
-     *         residents: [Human!]
+     *         residents: [Human!]!
      *     }
      */
     try schema.object(type: Planet.self) { planet in
@@ -184,8 +184,8 @@ let starWarsSchema = try! Schema<NoRoot, NoContext> { schema in
      *     type Human : Character {
      *         id: String!
      *         name: String!
-     *         friends: [Character!]
-     *         appearsIn: [Episode!]
+     *         friends: [Character!]!
+     *         appearsIn: [Episode!]!
      *         secretBackstory: String
      *         homePlanet: Planet!
      *     }
@@ -222,8 +222,8 @@ let starWarsSchema = try! Schema<NoRoot, NoContext> { schema in
      *     type Droid : Character {
      *         id: String!
      *         name: String!
-     *         friends: [Character!]
-     *         appearsIn: [Episode!]
+     *         friends: [Character!]!
+     *         appearsIn: [Episode!]!
      *         secretBackstory: String
      *         primaryFunction: String!
      *     }


### PR DESCRIPTION
Previously providing a field of type `[Int]` would define a GraphQL type `[Int!]` instead of defining `[Int!]!`. In order to define a `[Int!]` GraphQL type, one should now provide `[Int]?`.

The following cases are now properly handled:

| Swift Type  | GraphQL Type |
| ------------- | ------------- |
| [Int] | [Int!]! |
| [Int?] | [Int]! |
| [Int]? | [Int!] |
| [Int?]? | [Int] |

Simplifies `getGraphQLType(from:)` to always recurse at least once given a wrapped type to avoid duplicate logic.