### PR TITLE
Investigate having support for union

### DIFF
--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -119,6 +119,24 @@ public final class SchemaBuilder<Root, Context> {
 
     public func union<Type>(
         type: Type.Type,
+        members: [Any.Type]
+        ) throws {
+        let name = fixName(String(describing: Type.self))
+        try union(name: name, type: type, members: members)
+    }
+
+    public func union<Type>(
+        name: String,
+        type: Type.Type,
+        members: [Any.Type]
+    ) throws {
+        try union(name: name, type: type) { builder in
+            builder.types = members
+        }
+    }
+
+    public func union<Type>(
+        type: Type.Type,
         build: (UnionTypeBuilder<Type>) throws -> Void
         ) throws {
         let name = fixName(String(describing: Type.self))

--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -117,6 +117,32 @@ public final class SchemaBuilder<Root, Context> {
         map(Type.self, to: interfaceType)
     }
 
+    public func union<Type>(
+        type: Type.Type,
+        build: (UnionTypeBuilder<Type>) throws -> Void
+        ) throws {
+        let name = fixName(String(describing: Type.self))
+        try union(name: name, type: type, build: build)
+    }
+
+    public func union<Type>(
+        name: String,
+        type: Type.Type,
+        build: (UnionTypeBuilder<Type>) throws -> Void
+        ) throws {
+        let builder = UnionTypeBuilder<Type>()
+        try build(builder)
+
+        let interfaceType = try GraphQLUnionType(
+            name: name,
+            description: builder.description,
+            resolveType: builder.resolveType,
+            types: builder.types.map { try getObjectType(from: $0) }
+        )
+
+        map(Type.self, to: interfaceType)
+    }
+
     public func `enum`<Type : OutputType>(
         type: Type.Type,
         build: (EnumTypeBuilder<Type>) throws -> Void
@@ -517,3 +543,4 @@ public struct Schema<Root, Context> {
         )
     }
 }
+

--- a/Sources/Graphiti/Types/UnionType.swift
+++ b/Sources/Graphiti/Types/UnionType.swift
@@ -1,0 +1,8 @@
+import GraphQL
+
+public final class UnionTypeBuilder<Type> {
+    public var description: String? = nil
+    public var resolveType: GraphQLTypeResolve? = nil
+    public var types: [Any.Type] = []
+}
+

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsData.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsData.swift
@@ -60,8 +60,18 @@ struct Droid : Character {
     let primaryFunction: String
 }
 
+protocol SearchResult {}
+extension Planet: SearchResult {}
+extension Human: SearchResult {}
+extension Droid: SearchResult {}
+
 var tatooine = Planet(id:"10001", name: "Tatooine", diameter: 10465, rotationPeriod: 23, orbitalPeriod: 304,residents: [Human]() )
 var alderaan = Planet(id: "10002", name: "Alderaan", diameter: 12500, rotationPeriod: 24, orbitalPeriod: 364, residents: [Human]())
+
+let planetData: [String: Planet] = [
+    "10001": tatooine,
+    "10002": alderaan,
+]
 
 let luke = Human(
     id: "1000",
@@ -193,3 +203,30 @@ func getSecretBackStory() throws -> String? {
     throw Secret(description: "secretBackstory is secret.")
 }
 
+/**
+ * Allos us to query for either a Human, Droid, or Planet.
+ */
+func search(for value: String) -> [SearchResult] {
+    let value = value.lowercased()
+    var result: [SearchResult] = []
+
+    result.append(contentsOf: 
+        planetData.filter({
+            return $1.name.lowercased().range(of:value) != nil
+        }).map({ $1 })
+    )
+
+    result.append(contentsOf:
+        humanData.filter({
+            return $1.name.lowercased().range(of:value) != nil
+        }).map({ $1 })
+    )
+
+    result.append(contentsOf:
+        droidData.filter({
+            return $1.name.lowercased().range(of:value) != nil
+        }).map({ $1 })
+    )
+
+    return result
+}

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
@@ -41,9 +41,11 @@ class StarWarsIntrospectionTests : XCTestCase {
                             "name": "Query",
                         ],
                         [
+                            "name": "SearchResult",
+                        ],
+                        [
                             "name": "String",
                         ],
-
                         [
                             "name": "__Directive",
                         ],
@@ -124,6 +126,9 @@ class StarWarsIntrospectionTests : XCTestCase {
                         ],
                         [
                             "name": "Query",
+                        ],
+                        [
+                            "name": "SearchResult",
                         ],
                         [
                             "name": "String",
@@ -455,6 +460,24 @@ class StarWarsIntrospectionTests : XCTestCase {
                                     [
                                         "name": "id",
                                         "description": "id of the human",
+                                        "type": [
+                                            "name": nil,
+                                            "kind": "NON_NULL",
+                                            "ofType": [
+                                                "name": "String",
+                                                "kind": "SCALAR",
+                                            ]
+                                        ],
+                                        "defaultValue": nil,
+                                    ],
+                                ],
+                            ],
+                            [
+                                "name": "search",
+                                "args": [
+                                    [
+                                        "name": "query",
+                                        "description": "text to find",
                                         "type": [
                                             "name": nil,
                                             "kind": "NON_NULL",

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsQueryTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsQueryTests.swift
@@ -490,6 +490,38 @@ class StarWarsQueryTests : XCTestCase {
         let result = try schema.execute(request: query)
         XCTAssertEqual(result, expected)
     }
+
+    func testSearchQuery() throws {
+        let query = "query {" +
+            "    search(query: \"o\") {" +
+            "        ... on Planet {" +
+            "            name " +
+            "            diameter " +
+            "        }" +
+            "        ... on Human {" +
+            "            name " +
+            "        }" +
+            "        ... on Droid {" +
+            "            name " +
+            "            primaryFunction " +
+            "        }" +
+            "    }" +
+            "}"
+
+        let expected: Map = [
+            "data": [
+                "search": [
+                    [ "name": "Tatooine", "diameter": 10465 ],
+                    [ "name": "Han Solo" ],
+                    [ "name": "Leia Organa" ],
+                    [ "name": "C-3PO", "primaryFunction": "Protocol" ],
+                ],
+            ],
+            ]
+
+        let result = try starWarsSchema.execute(request: query)
+        XCTAssertEqual(result, expected)
+    }
 }
 
 extension StarWarsQueryTests {

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsSchema.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsSchema.swift
@@ -253,6 +253,15 @@ let starWarsSchema = try! Schema<NoRoot, NoContext> { schema in
     }
 
     /**
+     * A search result can be a include a number of different types.
+     *
+     * This implements the following type system shorthand:
+     *
+     * union SearchResult = Planet | Human | Droid
+     */
+    try schema.union(type: SearchResult.self, members: [ Planet.self, Human.self, Droid.self ])
+
+    /**
      * This is the type that will be the root of our query, and the
      * entry point into our schema. It gives us the ability to fetch
      * objects by their IDs, as well as to fetch the undisputed hero
@@ -264,6 +273,7 @@ let starWarsSchema = try! Schema<NoRoot, NoContext> { schema in
      *         hero(episode: Episode): Character
      *         human(id: String!): Human
      *         droid(id: String!): Droid
+     *         search(query: String!): SearchResult
      *     }
      */
     try schema.query { query in
@@ -298,6 +308,16 @@ let starWarsSchema = try! Schema<NoRoot, NoContext> { schema in
         try query.field(name: "droid") { (_, arguments: DroidArguments, _, _) in
             getDroid(id: arguments.id)
         }
+
+        struct SearchArguments : Arguments {
+            let query: String
+            static let descriptions = ["query": "text to find"]
+        }
+
+        try query.field(name: "search") { (_, arguments: SearchArguments, _, _) in
+            search(for: arguments.query)
+        }
+
     }
 
     schema.types = [Human.self, Droid.self]


### PR DESCRIPTION
Following up my own question in #9. I'm currently trying to think of the cleanest way to add union support to Graphiti.

This PR enables union support by way of a marker protocol. Usage is something like the following (trying to stick to the StarWars example)...

```swift
// define union marker protocol
protocol DroidAndPlanetUnion {}

// associate other members of the union
extension Droid: DroidAndPlanetUnion {}
extension Planet: DroidAndPlanetUnion {}

// building the unions
let starWarsSchema = try! Schema<NoRoot, NoContext> { schema in
    // ...
    try schema.union(type: DroidAndPlanetUnion.self) { union in
        union.description = "an unholy union of droids and planets"
        union.types = [ Droid.self, Planet.self ]
    }
    // alternatively if you don't need a description.
    try schema.union(type: DroidAndPlanetUnion.self, members: [ Droid.self, Planet.self ])
    // ...
}

```

I wasn't able to figure out a way to validate that the types provided in `union.types` implement the `DroidAndPlanetUnion` protocol.

Tests etc. can follow should we agree on the way forward.