### PR TITLE
Add support for adding basic input types to the schema via an InputOb…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 notifications:
   slack: zewo:VjyVCCQvTOw9yrbzQysZezD1
-os:
-  - linux
-  - osx
 language: generic
-sudo: required
-dist: trusty
-osx_image: xcode8
-install:
-  - eval "$(curl -sL https://raw.githubusercontent.com/Zewo/Zewo/master/Scripts/Travis/install.sh)"
+matrix:
+  include:
+    - os: osx
+      env: JOB=SwiftPM_OSX
+      osx_image: xcode8.3
+    - os: linux
+      env: JOB=SwiftPM_linux
+      dist: trusty
+      sudo: required
+      install:
+        -  travis_retry eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
 script:
-  - bash <(curl -s https://raw.githubusercontent.com/Zewo/Zewo/master/Scripts/Travis/build-test.sh) Graphiti
-#after_success:
-  - bash <(curl -s https://raw.githubusercontent.com/Zewo/Zewo/master/Scripts/Travis/report-coverage.sh)
+  - swift build -c release
+  - swift build
+  - swift test
+  - eval "$(curl -sL https://raw.githubusercontent.com/lgaches/swifttravisci/master/codecov)"
+

--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -91,6 +91,31 @@ public final class SchemaBuilder<Root, Context> {
         map(Type.self, to: objectType)
     }
 
+    public func inputObject<Type: InputType>(
+        type: Type.Type,
+        build: (InputObjectTypeBuilder<Root, Context, Type>) throws -> Void
+        ) throws {
+        let name = fixName(String(describing: Type.self))
+        try inputObject(name: name, type: type, build: build)
+    }
+    
+    public func inputObject<Type: InputType>(
+        name: String,
+        type: Type.Type,
+        build: (InputObjectTypeBuilder<Root, Context, Type>) throws -> Void
+        ) throws {
+        let builder = InputObjectTypeBuilder<Root, Context, Type>(schema: self)
+        try build(builder)
+        
+        let inputObjectType = try GraphQLInputObjectType(
+            name: name,
+            description: builder.description,
+            fields: builder.fields
+        )
+        
+        map(Type.self, to: inputObjectType)
+    }
+    
     public func interface<Type>(
         type: Type.Type,
         build: (InterfaceTypeBuilder<Root, Context, Type>) throws -> Void

--- a/Sources/Graphiti/Types/InputObjectType.swift
+++ b/Sources/Graphiti/Types/InputObjectType.swift
@@ -1,0 +1,24 @@
+import GraphQL
+
+public final class InputObjectTypeBuilder<Root, Context, Type> {
+    var schema: SchemaBuilder<Root, Context>
+    
+    init(schema: SchemaBuilder<Root, Context>) {
+        self.schema = schema
+    }
+    
+    public var description: String? = nil
+    
+    var fields: InputObjectConfigFieldMap = [:]
+    
+    /// Export all properties using reflection
+    ///
+    /// - Throws: Reflection Errors
+    public func exportFields() throws {
+        for property in try properties(Type.self) {
+            let field = InputObjectField(type: try schema.getInputType(from: property.type, field: property.key))
+            fields[property.key] = field
+        }
+    }
+}
+


### PR DESCRIPTION
…jectTypeBuilder

Thus adding support for mutations that take input types as parameters.

This change relies on the minor changes to GraphQL in [this pull request](https://github.com/GraphQLSwift/GraphQL/pull/23)