### PR TITLE
Update Swift version badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Output:
 
 This project is released under the MIT license. See [LICENSE](LICENSE) for details.
 
-[swift-badge]: https://img.shields.io/badge/Swift-4-orange.svg?style=flat
+[swift-badge]: https://img.shields.io/badge/Swift-5-orange.svg?style=flat
 [swift-url]: https://swift.org
 [mit-badge]: https://img.shields.io/badge/License-MIT-blue.svg?style=flat
 [mit-url]: https://tldrlegal.com/license/mit-license


### PR DESCRIPTION
The CI buils is failing as apparently .travis.yml wasn't updated for Swift 5.0.