### PR TITLE
Publicize schema property

### DIFF
--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -51,7 +51,7 @@ public struct SchemaBuilder<RootType : FieldKeyProvider, Context> {
 }
 
 public final class Schema<RootType : FieldKeyProvider, Context> {
-    private let schema: GraphQLSchema
+    public let schema: GraphQLSchema
 
     public init(@SchemaBuilder<RootType, Context> component: () -> SchemaComponent<RootType, Context>) {
         let component = component()


### PR DESCRIPTION
This was previously publicized in https://github.com/GraphQLSwift/Graphiti/pull/27, but it looks like it reverted back to `private` as of
https://github.com/GraphQLSwift/Graphiti/commit/5d0e93302505e6a28ea9ccbb7f9a78cc1a0f89ef#diff-866deecae21b5220ab43fa7ede45c86bR54. Was this intentional? I'm using it in conjunction with https://github.com/StevenLambion/GraphQLRouteCollection.