### PR TITLE
Expose designated inits for Graphiti types

### DIFF
--- a/Sources/Graphiti/Input/Input.swift
+++ b/Sources/Graphiti/Input/Input.swift
@@ -24,9 +24,9 @@ public final class Input<Resolver, Context, InputObjectType : Decodable> : Compo
         return map
     }
     
-    init(
+    public init(
         type: InputObjectType.Type,
-        name: String?,
+        name: String? = nil,
         fields: [InputFieldComponent<InputObjectType, Context>]
     ) {
         self.fields = fields

--- a/Sources/Graphiti/Mutation/Mutation.swift
+++ b/Sources/Graphiti/Mutation/Mutation.swift
@@ -27,7 +27,7 @@ public final class Mutation<Resolver, Context> : Component<Resolver, Context> {
         return map
     }
     
-    private init(
+    public init(
         name: String,
         fields: [FieldComponent<Resolver, Context>]
     ) {

--- a/Sources/Graphiti/Query/Query.swift
+++ b/Sources/Graphiti/Query/Query.swift
@@ -27,7 +27,7 @@ public final class Query<Resolver, Context> : Component<Resolver, Context> {
         return map
     }
     
-    private init(
+    public init(
         name: String,
         fields: [FieldComponent<Resolver, Context>]
     ) {

--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -4,7 +4,7 @@ import NIO
 public final class Schema<Resolver, Context> {
     public let schema: GraphQLSchema
 
-    private init(components: [Component<Resolver, Context>]) throws {
+    public init(components: [Component<Resolver, Context>]) throws {
         let typeProvider = SchemaTypeProvider()
         
         for component in components {

--- a/Sources/Graphiti/Type/Type.swift
+++ b/Sources/Graphiti/Type/Type.swift
@@ -33,10 +33,10 @@ public final class Type<Resolver, Context, ObjectType : Encodable> : Component<R
         return map
     }
     
-    private init(
+    public init(
         type: ObjectType.Type,
-        name: String?,
-        interfaces: [Any.Type],
+        name: String? = nil,
+        interfaces: [Any.Type] = [],
         fields: [FieldComponent<ObjectType, Context>]
     ) {
         self.interfaces = interfaces


### PR DESCRIPTION
Expose designated inits for Graphiti types to allow type definition programatically in addition to using function builders