### PR TITLE
Adds support for reference types on Input fields

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/GraphQLSwift/GraphQL.git",
         "state": {
           "branch": null,
-          "revision": "abf41c20c79331444ee3a290373d7c647c244383",
-          "version": "1.2.0"
+          "revision": "7aa6430a883f7075cc54cdba2c7048eb3a458422",
+          "version": "1.3.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "Graphiti", targets: ["Graphiti"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", .upToNextMajor(from: "1.2.0"))
+        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", .upToNextMajor(from: "1.3.0"))
     ],
     targets: [
         .target(name: "Graphiti", dependencies: ["GraphQL"]),

--- a/Sources/Graphiti/Input/Input.swift
+++ b/Sources/Graphiti/Input/Input.swift
@@ -13,8 +13,8 @@ public final class Input<Resolver, Context, InputObjectType : Decodable> : Compo
         try typeProvider.map(InputObjectType.self, to: inputObjectType)
     }
     
-    func fields(typeProvider: TypeProvider) throws -> InputObjectConfigFieldMap {
-        var map: InputObjectConfigFieldMap = [:]
+    func fields(typeProvider: TypeProvider) throws -> InputObjectFieldMap {
+        var map: InputObjectFieldMap = [:]
         
         for field in fields {
             let (name, field) = try field.field(typeProvider: typeProvider)

--- a/Sources/Graphiti/InputField/InputField.swift
+++ b/Sources/Graphiti/InputField/InputField.swift
@@ -32,6 +32,16 @@ public extension InputField {
     }
 }
 
+public extension InputField {
+    convenience init<KeyPathType>(
+        _ name: String,
+        at keyPath: KeyPath<InputObjectType, KeyPathType>,
+        as: FieldType.Type
+    ) {
+        self.init(name: name)
+    }
+}
+
 public extension InputField where FieldType : Encodable {
     func defaultValue(_ defaultValue: FieldType) -> Self {
         self.defaultValue = AnyEncodable(defaultValue)


### PR DESCRIPTION
See this PR: https://github.com/GraphQLSwift/GraphQL/pull/78

This exposes the new functionality from the PR above by adding an InputField constructor with an `as` field to allow the user to specify a `TypeReference`.