### PR TITLE
Get Star wars sample compiling on linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches: [ master ]
     paths-ignore: [ README.md ]
+  workflow_dispatch:
+  
 jobs:
   macos:
     name: Build and test on macOS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,22 +8,37 @@ on:
     branches: [ master ]
     paths-ignore: [ README.md ]
 jobs:
-  build:
-    name: Build and test on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-10.15, ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+  macos:
+    name: Build and test on macOS
+    runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set code coverage path 
       run: echo "codecov_path=$(swift test --show-codecov-path)" >> $GITHUB_ENV
     - name: Test and publish code coverage to Code Climate
       uses: paulofaria/codeclimate-action@master
-      if: matrix.os == 'macos-10.15'
       env:
         CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
       with:
         downloadUrl: https://github.com/paulofaria/test-reporter/releases/download/0.9.0/test-reporter-0.9.0-darwin-amd64
         coverageCommand: swift test --enable-test-discovery --enable-code-coverage
         coverageLocations: ${{ env.codecov_path }}:lcov-json
+
+  linux:
+    name: Build and test on ${{ matrix.tag }}-${{ matrix.os }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - focal
+          - bionic
+        tag:
+          - swift:5.3
+          - swift:5.4
+    container:
+      image: ${{ matrix.tag }}-${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Test
+      run: swift test --enable-test-discovery --enable-code-coverage --sanitize=thread

--- a/Tests/GraphitiTests/StarWarsAPI/StarWarsAPI.swift
+++ b/Tests/GraphitiTests/StarWarsAPI/StarWarsAPI.swift
@@ -2,9 +2,6 @@ import Graphiti
 
 public struct StarWarsAPI : API {
     public let resolver = StarWarsResolver()
-    public let context = StarWarsContext()
-    
-    public init() {}
     
     public let schema = try! Schema<StarWarsResolver, StarWarsContext> {
         Enum(Episode.self) {

--- a/Tests/GraphitiTests/StarWarsAPI/StarWarsContext.swift
+++ b/Tests/GraphitiTests/StarWarsAPI/StarWarsContext.swift
@@ -6,7 +6,7 @@
  * values in a more complex demo.
  */
 public final class StarWarsContext {
-    private lazy var tatooine = Planet(
+    private static var tatooine = Planet(
         id:"10001",
         name: "Tatooine",
         diameter: 10465,
@@ -15,7 +15,7 @@ public final class StarWarsContext {
         residents: []
     )
     
-    private lazy var alderaan = Planet(
+    private static var alderaan = Planet(
         id: "10002",
         name: "Alderaan",
         diameter: 12500,
@@ -24,12 +24,12 @@ public final class StarWarsContext {
         residents: []
     )
     
-    private lazy var planetData: [String: Planet] = [
+    private static var planetData: [String: Planet] = [
         "10001": tatooine,
         "10002": alderaan,
     ]
     
-    private lazy var luke = Human(
+    private static var luke = Human(
         id: "1000",
         name: "Luke Skywalker",
         friends: ["1002", "1003", "2000", "2001"],
@@ -37,7 +37,7 @@ public final class StarWarsContext {
         homePlanet: tatooine
     )
     
-    private lazy var vader = Human(
+    private static var vader = Human(
         id: "1001",
         name: "Darth Vader",
         friends: [ "1004" ],
@@ -45,7 +45,7 @@ public final class StarWarsContext {
         homePlanet: tatooine
     )
     
-    private lazy var han = Human(
+    private static var han = Human(
         id: "1002",
         name: "Han Solo",
         friends: ["1000", "1003", "2001"],
@@ -53,7 +53,7 @@ public final class StarWarsContext {
         homePlanet: alderaan
     )
     
-    private lazy var leia = Human(
+    private static var leia = Human(
         id: "1003",
         name: "Leia Organa",
         friends: ["1000", "1002", "2000", "2001"],
@@ -61,7 +61,7 @@ public final class StarWarsContext {
         homePlanet: alderaan
     )
     
-    private lazy var tarkin = Human(
+    private static var tarkin = Human(
         id: "1004",
         name: "Wilhuff Tarkin",
         friends: ["1001"],
@@ -69,7 +69,7 @@ public final class StarWarsContext {
         homePlanet: alderaan
     )
     
-    private lazy var humanData: [String: Human] = [
+    private static var humanData: [String: Human] = [
         "1000": luke,
         "1001": vader,
         "1002": han,
@@ -77,7 +77,7 @@ public final class StarWarsContext {
         "1004": tarkin,
     ]
     
-    private lazy var c3po = Droid(
+    private static var c3po = Droid(
         id: "2000",
         name: "C-3PO",
         friends: ["1000", "1002", "1003", "2001"],
@@ -85,7 +85,7 @@ public final class StarWarsContext {
         primaryFunction: "Protocol"
     )
     
-    private lazy var r2d2 = Droid(
+    private static var r2d2 = Droid(
         id: "2001",
         name: "R2-D2",
         friends: [ "1000", "1002", "1003" ],
@@ -93,7 +93,7 @@ public final class StarWarsContext {
         primaryFunction: "Astromech"
     )
     
-    private lazy var droidData: [String: Droid] = [
+    private static var droidData: [String: Droid] = [
         "2000": c3po,
         "2001": r2d2,
     ]
@@ -104,7 +104,7 @@ public final class StarWarsContext {
      * Helper function to get a character by ID.
      */
     public func getCharacter(id: String) -> Character? {
-        humanData[id] ?? droidData[id]
+        Self.humanData[id] ?? Self.droidData[id]
     }
     
     /**
@@ -122,24 +122,24 @@ public final class StarWarsContext {
     public func getHero(of episode: Episode?) -> Character {
         if episode == .empire {
             // Luke is the hero of Episode V.
-            return luke
+            return Self.luke
         }
         // R2-D2 is the hero otherwise.
-        return r2d2
+        return Self.r2d2
     }
     
     /**
      * Allows us to query for the human with the given id.
      */
     public func getHuman(id: String) -> Human? {
-        humanData[id]
+        Self.humanData[id]
     }
     
     /**
      * Allows us to query for the droid with the given id.
      */
     public func getDroid(id: String) -> Droid? {
-        droidData[id]
+        Self.droidData[id]
     }
     
     /**
@@ -157,7 +157,7 @@ public final class StarWarsContext {
      * Allows us to query for a Planet.
      */
     public func getPlanets(query: String) -> [Planet] {
-        planetData
+        Self.planetData
             .sorted(by: { $0.key < $1.key })
             .map({ $1 })
             .filter({ $0.name.lowercased().contains(query.lowercased()) })
@@ -167,7 +167,7 @@ public final class StarWarsContext {
      * Allows us to query for a Human.
      */
     public func getHumans(query: String) -> [Human] {
-        humanData
+        Self.humanData
             .sorted(by: { $0.key < $1.key })
             .map({ $1 })
             .filter({ $0.name.lowercased().contains(query.lowercased()) })
@@ -177,7 +177,7 @@ public final class StarWarsContext {
      * Allows us to query for a Droid.
      */
     public func getDroids(query: String) -> [Droid] {
-        droidData
+        Self.droidData
             .sorted(by: { $0.key < $1.key })
             .map({ $1 })
             .filter({ $0.name.lowercased().contains(query.lowercased()) })

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
@@ -88,7 +88,7 @@ class StarWarsIntrospectionTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -121,7 +121,7 @@ class StarWarsIntrospectionTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -150,7 +150,7 @@ class StarWarsIntrospectionTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -181,7 +181,7 @@ class StarWarsIntrospectionTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -212,7 +212,7 @@ class StarWarsIntrospectionTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -292,7 +292,7 @@ class StarWarsIntrospectionTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -397,7 +397,7 @@ class StarWarsIntrospectionTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -515,7 +515,7 @@ class StarWarsIntrospectionTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -546,7 +546,7 @@ class StarWarsIntrospectionTests : XCTestCase {
         
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsQueryTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsQueryTests.swift
@@ -26,7 +26,7 @@ class StarWarsQueryTests : XCTestCase {
         
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -67,7 +67,7 @@ class StarWarsQueryTests : XCTestCase {
         
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -136,7 +136,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -167,7 +167,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -204,7 +204,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group,
             variables: params
         ).whenSuccess { result in
@@ -228,7 +228,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group,
             variables: params
         ).whenSuccess { result in
@@ -250,7 +250,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group,
             variables: params
         ).whenSuccess { result in
@@ -282,7 +282,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -319,7 +319,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -360,7 +360,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -403,7 +403,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -436,7 +436,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -469,7 +469,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -509,7 +509,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -575,7 +575,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -615,7 +615,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -652,7 +652,6 @@ class StarWarsQueryTests : XCTestCase {
         
         struct MyAPI : API {
             var resolver: TestResolver = TestResolver()
-            var context: NoContext = NoContext()
             
             let schema = try! Schema<TestResolver, NoContext> {
                 Type(A.self) {
@@ -701,7 +700,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: NoContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -745,7 +744,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -784,7 +783,7 @@ class StarWarsQueryTests : XCTestCase {
 
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)
@@ -822,7 +821,7 @@ class StarWarsQueryTests : XCTestCase {
         
         api.execute(
             request: query,
-            context: api.context,
+            context: StarWarsContext(),
             on: group
         ).whenSuccess { result in
             XCTAssertEqual(result, expected)


### PR DESCRIPTION
Hi,

These changes are just to get the star wars sample to compile on swift 5.3. You should probably take it up with the swift team to find out why the original code was crashing the compiler. The will fix issue #57 

I added a section to the build.yml to get Linux tests working as they weren't working before