### PR TITLE
Remove reference to Runtime

### DIFF
--- a/Sources/Graphiti/Definition/TypeProvider.swift
+++ b/Sources/Graphiti/Definition/TypeProvider.swift
@@ -1,6 +1,6 @@
 import GraphQL
 
-protocol TypeProvider : class {
+protocol TypeProvider : AnyObject {
     var graphQLTypeMap: [AnyType: GraphQLType] { get set }
 }
 

--- a/Sources/Graphiti/Field/Field/Field.swift
+++ b/Sources/Graphiti/Field/Field/Field.swift
@@ -1,5 +1,4 @@
 import GraphQL
-import Runtime
 
 public class Field<ObjectType, Context, FieldType, Arguments : Decodable> : FieldComponent<ObjectType, Context> {
     let name: String

--- a/Sources/Graphiti/Subscription/SubscribeField.swift
+++ b/Sources/Graphiti/Subscription/SubscribeField.swift
@@ -1,5 +1,4 @@
 import GraphQL
-import Runtime
 
 // Subscription resolver MUST return an Observer<Any>, not a specific type, due to lack of support for covariance generics in Swift
 


### PR DESCRIPTION
There were a couple of unnecessary `import Runtime` in the code.
These will break with next release of GraphQL