### PR TITLE
Fixes functionBuilder warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,21 +10,22 @@ on:
   workflow_dispatch:
   
 jobs:
-  macos:
-    name: Build and test on macOS
-    runs-on: macOS-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set code coverage path 
-      run: echo "codecov_path=$(swift test --show-codecov-path)" >> $GITHUB_ENV
-    - name: Test and publish code coverage to Code Climate
-      uses: paulofaria/codeclimate-action@master
-      env:
-        CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
-      with:
-        downloadUrl: https://github.com/paulofaria/test-reporter/releases/download/0.9.0/test-reporter-0.9.0-darwin-amd64
-        coverageCommand: swift test --enable-test-discovery --enable-code-coverage
-        coverageLocations: ${{ env.codecov_path }}:lcov-json
+  # Disabled until https://github.com/paulofaria/test-reporter is updated to Swift 5.4
+  # macos:
+  #   name: Build and test on macOS
+  #   runs-on: macOS-latest
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set code coverage path 
+  #     run: echo "codecov_path=$(swift test --show-codecov-path)" >> $GITHUB_ENV
+  #   - name: Test and publish code coverage to Code Climate
+  #     uses: paulofaria/codeclimate-action@master
+  #     env:
+  #       CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+  #     with:
+  #       downloadUrl: https://github.com/paulofaria/test-reporter/releases/download/0.9.0/test-reporter-0.9.0-darwin-amd64
+  #       coverageCommand: swift test --enable-test-discovery --enable-code-coverage
+  #       coverageLocations: ${{ env.codecov_path }}:lcov-json
 
   linux:
     name: Build and test on ${{ matrix.tag }}-${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
           - focal
           - bionic
         tag:
-          - swift:5.3
           - swift:5.4
     container:
       image: ${{ matrix.tag }}-${{ matrix.os }}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Check the [Star Wars API](Tests/GraphitiTests/StarWarsAPI/StarWarsAPI.swift) for
 
 This project is released under the MIT license. See [LICENSE](LICENSE) for details.
 
-[swift-badge]: https://img.shields.io/badge/Swift-5.2-orange.svg?style=flat
+[swift-badge]: https://img.shields.io/badge/Swift-5.4-orange.svg?style=flat
 [swift-url]: https://swift.org
 
 [mit-badge]: https://img.shields.io/badge/License-MIT-blue.svg?style=flat

--- a/Sources/Graphiti/Argument/ArgumentComponentBuilder.swift
+++ b/Sources/Graphiti/Argument/ArgumentComponentBuilder.swift
@@ -1,4 +1,4 @@
-@_functionBuilder
+@resultBuilder
 public struct ArgumentComponentBuilder<ArgumentsType : Decodable> {
     public static func buildExpression(_ component: ArgumentComponent<ArgumentsType>) -> ArgumentComponent<ArgumentsType> {
         component

--- a/Sources/Graphiti/Component/ComponentBuilder.swift
+++ b/Sources/Graphiti/Component/ComponentBuilder.swift
@@ -1,4 +1,4 @@
-@_functionBuilder
+@resultBuilder
 public struct ComponentBuilder<Resolver, Context> {
     public static func buildExpression(_ component: Component<Resolver, Context>) -> Component<Resolver, Context> {
         component

--- a/Sources/Graphiti/Field/Field/FieldComponentBuilder.swift
+++ b/Sources/Graphiti/Field/Field/FieldComponentBuilder.swift
@@ -1,4 +1,4 @@
-@_functionBuilder
+@resultBuilder
 public struct FieldComponentBuilder<ObjectType, Context> {
     public static func buildExpression(_ component: FieldComponent<ObjectType, Context>) -> FieldComponent<ObjectType, Context> {
         component

--- a/Sources/Graphiti/InputField/InputFieldComponentBuilder.swift
+++ b/Sources/Graphiti/InputField/InputFieldComponentBuilder.swift
@@ -1,4 +1,4 @@
-@_functionBuilder
+@resultBuilder
 public struct InputFieldComponentBuilder<InputObjectType, Context> {
     public static func buildExpression(_ component: InputFieldComponent<InputObjectType, Context>) -> InputFieldComponent<InputObjectType, Context> {
         component

--- a/Sources/Graphiti/Value/ValueBuilder.swift
+++ b/Sources/Graphiti/Value/ValueBuilder.swift
@@ -1,4 +1,4 @@
-@_functionBuilder
+@resultBuilder
 public struct ValueBuilder<EnumType : Encodable & RawRepresentable> where EnumType.RawValue == String {
     public static func buildExpression(_ value: Value<EnumType>) -> Value<EnumType> {
         value


### PR DESCRIPTION
This change requires Swift 5.4, and is not backwards compatible with previous versions of Swift.