### PR TITLE
Preserve result order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+Package.resolved
 
 ### SwiftPM ###
 /.build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-Package.resolved
 
 ### SwiftPM ###
 /.build

--- a/Package.resolved
+++ b/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections",
+        "state": {
+          "branch": null,
+          "revision": "d45e63421d3dff834949ac69d3c37691e994bd69",
+          "version": "0.0.3"
+        }
+      },
+      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,30 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "CRuntime",
-        "repositoryURL": "https://github.com/wickwirew/CRuntime.git",
-        "state": {
-          "branch": null,
-          "revision": "95f911318d8c885f6fc05e971471f94adfd39405",
-          "version": "2.1.2"
-        }
-      },
-      {
         "package": "GraphQL",
         "repositoryURL": "https://github.com/GraphQLSwift/GraphQL.git",
         "state": {
           "branch": null,
-          "revision": "7aa6430a883f7075cc54cdba2c7048eb3a458422",
-          "version": "1.3.0"
-        }
-      },
-      {
-        "package": "Runtime",
-        "repositoryURL": "https://github.com/wickwirew/Runtime.git",
-        "state": {
-          "branch": null,
-          "revision": "c167476b07fe8cc65fdf064076a4081c3269d14a",
-          "version": "2.1.0"
+          "revision": "e5de315125f8220334ba3799bbd78c7c1ed529f7",
+          "version": "2.0.0"
         }
       },
       {
@@ -42,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "acf5465b5e7fb9aeda54a34d16fb44c31a399715",
-          "version": "2.20.2"
+          "revision": "d161bf658780b209c185994528e7e24376cf7283",
+          "version": "2.29.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(
@@ -7,14 +7,10 @@ let package = Package(
         .library(name: "Graphiti", targets: ["Graphiti"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", .upToNextMajor(from: "1.3.0")),
-        .package(url: "https://github.com/apple/swift-collections", .upToNextMajor(from: "0.0.3"))
+        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", .upToNextMajor(from: "2.0.0"))
     ],
     targets: [
-        .target(name: "Graphiti", dependencies: [
-            "GraphQL",
-            .product(name: "OrderedCollections", package: "swift-collections"),
-        ]),
+        .target(name: "Graphiti", dependencies: ["GraphQL"]),
         .testTarget(name: "GraphitiTests", dependencies: ["Graphiti"]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -7,10 +7,14 @@ let package = Package(
         .library(name: "Graphiti", targets: ["Graphiti"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", .upToNextMajor(from: "1.3.0"))
+        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", .upToNextMajor(from: "1.3.0")),
+        .package(url: "https://github.com/apple/swift-collections", .upToNextMajor(from: "0.0.3"))
     ],
     targets: [
-        .target(name: "Graphiti", dependencies: ["GraphQL"]),
+        .target(name: "Graphiti", dependencies: [
+            "GraphQL",
+            .product(name: "OrderedCollections", package: "swift-collections"),
+        ]),
         .testTarget(name: "GraphitiTests", dependencies: ["Graphiti"]),
     ]
 )

--- a/Sources/Graphiti/Scalar/Scalar.swift
+++ b/Sources/Graphiti/Scalar/Scalar.swift
@@ -1,4 +1,5 @@
 import GraphQL
+import OrderedCollections
 
 open class Scalar<Resolver, Context, ScalarType : Codable> : Component<Resolver, Context> {
     override func update(typeProvider: SchemaTypeProvider) throws {
@@ -92,7 +93,7 @@ extension GraphQL.Value {
         if
             let value = self as? ObjectValue
         {
-            let dictionary = value.fields.reduce(into: [:]) { result, field in
+            let dictionary: OrderedDictionary<String, Map> = value.fields.reduce(into: [:]) { result, field in
                 result[field.name.value] = field.value.map
             }
             

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
@@ -331,8 +331,8 @@ class StarWarsIntrospectionTests : XCTestCase {
                                 "name": nil,
                                 "kind": "NON_NULL",
                                 "ofType": [
-                                    "kind": "LIST",
-                                    "name": nil
+                                    "name": nil,
+                                    "kind": "LIST"
                                 ]
                             ]
                         ],
@@ -342,8 +342,8 @@ class StarWarsIntrospectionTests : XCTestCase {
                                 "name": nil,
                                 "kind": "NON_NULL",
                                 "ofType": [
-                                    "kind": "LIST",
-                                    "name": nil
+                                    "name": nil,
+                                    "kind": "LIST"
                                 ]
                             ]
                         ],


### PR DESCRIPTION
PR to align Graphiti with this GraphQL PR: https://github.com/GraphQLSwift/GraphQL/issues/60

@adam-fowler Heads up - I reverted the swift-tools-version because [this](http://openradar.appspot.com/FB7691693) issue is still present in XCode 12.4. This means that anyone with XCode < 12.5 cannot build Graphiti, even if they are using a Swift 5.4 toolchain.