### PR TITLE
feat: Type update

### DIFF
--- a/Sources/Graphiti/Type/Type.swift
+++ b/Sources/Graphiti/Type/Type.swift
@@ -1,6 +1,8 @@
 import GraphQL
 
-public final class Type<Resolver, Context, ObjectType : Encodable> : Component<Resolver, Context> {
+public typealias Type = _Type
+
+public final class _Type<Resolver, Context, ObjectType : Encodable> : Component<Resolver, Context> {
     let interfaces: [Any.Type]
     let fields: [FieldComponent<ObjectType, Context>]
     


### PR DESCRIPTION
Remove ambiguity of Type and enable ability to extend the type by
- Renaming Type to _Type
- Creating typealias Type for _Type to keep backward compatibility

> _Currently, it's simply impossible to extend Type from outside of Graphiti, it's ambiguous and can't be specified by module prefix for extension_