### PR TITLE
Swift Concurrency Support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/GraphQLSwift/GraphQL.git",
         "state": {
           "branch": null,
-          "revision": "283cc4de56b994a00b2724328221b7a1bc846ddc",
-          "version": "2.2.1"
+          "revision": "ebd2ea40676f8bcbdfd6088c408f3ed321c1a905",
+          "version": "2.4.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "d6e3762e0a5f7ede652559f53623baf11006e17c",
-          "version": "2.39.0"
+          "revision": "124119f0bb12384cef35aa041d7c3a686108722d",
+          "version": "2.40.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "Graphiti", targets: ["Graphiti"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", .upToNextMajor(from: "2.0.0"))
+        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "2.4.0")
     ],
     targets: [
         .target(name: "Graphiti", dependencies: ["GraphQL"]),

--- a/Sources/Graphiti/API/API.swift
+++ b/Sources/Graphiti/API/API.swift
@@ -43,3 +43,46 @@ extension API {
         )
     }
 }
+
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+extension API {
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    public func execute(
+        request: String,
+        context: ContextType,
+        on eventLoopGroup: EventLoopGroup,
+        variables: [String: Map] = [:],
+        operationName: String? = nil
+    ) async throws -> GraphQLResult {
+        return try await schema.execute(
+            request: request,
+            resolver: resolver,
+            context: context,
+            eventLoopGroup: eventLoopGroup,
+            variables: variables,
+            operationName: operationName
+        ).get()
+    }
+    
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    public func subscribe(
+        request: String,
+        context: ContextType,
+        on eventLoopGroup: EventLoopGroup,
+        variables: [String: Map] = [:],
+        operationName: String? = nil
+    ) async throws -> SubscriptionResult {
+        return try await schema.subscribe(
+            request: request,
+            resolver: resolver,
+            context: context,
+            eventLoopGroup: eventLoopGroup,
+            variables: variables,
+            operationName: operationName
+        ).get()
+    }
+}
+
+#endif

--- a/Sources/Graphiti/Field/Resolve/ConcurrentResolve.swift
+++ b/Sources/Graphiti/Field/Resolve/ConcurrentResolve.swift
@@ -1,0 +1,13 @@
+import NIO
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+public typealias ConcurrentResolve<ObjectType, Context, Arguments, ResolveType> = (
+    _ object: ObjectType
+) -> (
+    _ context: Context,
+    _ arguments: Arguments
+) async throws -> ResolveType
+
+#endif

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
@@ -1,0 +1,341 @@
+import XCTest
+import GraphQL
+import NIO
+@testable import Graphiti
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+let pubsub = SimplePubSub<User>()
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+extension HelloResolver {
+    func asyncHello(
+        context: HelloContext,
+        arguments: NoArguments
+    ) async -> String {
+        return await Task {
+            context.hello()
+        }.value
+    }
+    
+    func subscribeUser(context: HelloContext, arguments: NoArguments) -> EventStream<User> {
+        pubsub.subscribe()
+    }
+    
+    func futureSubscribeUser(context: HelloContext, arguments: NoArguments, group: EventLoopGroup) -> EventLoopFuture<EventStream<User>> {
+        group.next().makeSucceededFuture(pubsub.subscribe())
+    }
+    
+    func asyncSubscribeUser(context: HelloContext, arguments: NoArguments) async -> EventStream<User> {
+        return await Task {
+            pubsub.subscribe()
+        }.value
+    }
+}
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+// Same as the HelloAPI, except with an async query and a few subscription fields
+struct HelloAsyncAPI : API {
+    let resolver = HelloResolver()
+    let context = HelloContext()
+    
+    let schema = try! Schema<HelloResolver, HelloContext> {
+        Scalar(Float.self)
+            .description("The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).")
+
+        Scalar(ID.self)
+            .description("The `ID` scalar type represents a unique identifier.")
+        
+        Type(User.self) {
+            Field("id", at: \.id)
+            Field("name", at: \.name)
+            Field("friends", at: \.friends, as: [TypeReference<User>]?.self)
+        }
+
+        Input(UserInput.self) {
+            InputField("id", at: \.id)
+            InputField("name", at: \.name)
+            InputField("friends", at: \.friends, as: [TypeReference<UserInput>]?.self)
+        }
+        
+        Type(UserEvent.self) {
+            Field("user", at: \.user)
+        }
+        
+        Query {
+            Field("hello", at: HelloResolver.hello)
+            Field("futureHello", at: HelloResolver.futureHello)
+            Field("asyncHello", at: HelloResolver.asyncHello)
+            
+            
+            Field("float", at: HelloResolver.getFloat) {
+                Argument("float", at: \.float)
+            }
+            
+            Field("id", at: HelloResolver.getId) {
+                Argument("id", at: \.id)
+            }
+            
+            Field("user", at: HelloResolver.getUser)
+        }
+
+        Mutation {
+            Field("addUser", at: HelloResolver.addUser) {
+                Argument("user", at: \.user)
+            }
+        }
+        
+        Subscription {
+            SubscriptionField("subscribeUser", as: User.self, atSub: HelloResolver.subscribeUser)
+            SubscriptionField("subscribeUserEvent", at: User.toEvent, atSub: HelloResolver.subscribeUser)
+            
+            SubscriptionField("futureSubscribeUser", as: User.self, atSub: HelloResolver.subscribeUser)
+            SubscriptionField("asyncSubscribeUser", as: User.self, atSub: HelloResolver.subscribeUser)
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+class HelloWorldAsyncTests : XCTestCase {
+    private let api = HelloAsyncAPI()
+    private var group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+    
+    /// Tests that async version of API.execute works as expected
+    func testAsyncExecute() async throws {
+        let query = "{ hello }"
+        let result = try await api.execute(
+            request: query,
+            context: api.context,
+            on: group
+        )
+        XCTAssertEqual(
+            result,
+            GraphQLResult(data: ["hello": "world"])
+        )
+    }
+    
+    /// Tests that async fields (via ConcurrentResolve) are resolved successfully
+    func testAsyncHello() async throws {
+        let query = "{ asyncHello }"
+        let result = try await api.execute(
+            request: query,
+            context: api.context,
+            on: group
+        )
+        XCTAssertEqual(
+            result,
+            GraphQLResult(data: ["asyncHello": "world"])
+        )
+    }
+    
+    /// Tests subscription when the sourceEventStream type matches the resolved type (i.e. the normal resolution function should just short-circuit to the sourceEventStream object)
+    func testSubscriptionSelf() async throws {
+        let request = """
+        subscription {
+            subscribeUser {
+                id
+                name
+            }
+        }
+        """
+        
+        let subscriptionResult = try api.subscribe(
+            request: request,
+            context: api.context,
+            on: group
+        ).wait()
+        guard let subscription = subscriptionResult.stream else {
+            XCTFail(subscriptionResult.errors.description)
+            return
+        }
+        guard let stream = subscription as? ConcurrentEventStream else {
+            XCTFail("stream isn't ConcurrentEventStream")
+            return
+        }
+        var iterator = stream.stream.makeAsyncIterator()
+        
+        pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
+        
+        let result = try await iterator.next()?.get()
+        XCTAssertEqual(
+            result,
+            GraphQLResult(data: [
+                "subscribeUser": [
+                    "id": "124",
+                    "name": "Jerry"
+                ]
+            ])
+        )
+    }
+    
+    /// Tests subscription when the sourceEventStream type does not match the resolved type (i.e. there is a non-trivial resolution function that transforms the sourceEventStream object)
+    func testSubscriptionEvent() async throws {
+        let request = """
+        subscription {
+            subscribeUserEvent {
+                user {
+                    id
+                    name
+                }
+            }
+        }
+        """
+        
+        let subscriptionResult = try await api.subscribe(
+            request: request,
+            context: api.context,
+            on: group
+        )
+        guard let subscription = subscriptionResult.stream else {
+            XCTFail(subscriptionResult.errors.description)
+            return
+        }
+        guard let stream = subscription as? ConcurrentEventStream else {
+            XCTFail("stream isn't ConcurrentEventStream")
+            return
+        }
+        var iterator = stream.stream.makeAsyncIterator()
+        
+        pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
+        
+        let result = try await iterator.next()?.get()
+        XCTAssertEqual(
+            result,
+            GraphQLResult(data: [
+                "subscribeUserEvent": [
+                    "user": [
+                        "id": "124",
+                        "name": "Jerry"
+                    ]
+                ]
+            ])
+        )
+    }
+    
+    /// Tests that subscription resolvers that return futures work
+    func testFutureSubscription() async throws {
+        let request = """
+        subscription {
+            futureSubscribeUser {
+                id
+                name
+            }
+        }
+        """
+        
+        let subscriptionResult = try await api.subscribe(
+            request: request,
+            context: api.context,
+            on: group
+        )
+        guard let subscription = subscriptionResult.stream else {
+            XCTFail(subscriptionResult.errors.description)
+            return
+        }
+        guard let stream = subscription as? ConcurrentEventStream else {
+            XCTFail("stream isn't ConcurrentEventStream")
+            return
+        }
+        var iterator = stream.stream.makeAsyncIterator()
+        
+        pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
+        
+        let result = try await iterator.next()?.get()
+        XCTAssertEqual(
+            result,
+            GraphQLResult(data: [
+                "futureSubscribeUser": [
+                    "id": "124",
+                    "name": "Jerry"
+                ]
+            ])
+        )
+    }
+    
+    /// Tests that subscription resolvers that are async work
+    func testAsyncSubscription() async throws {
+        let request = """
+        subscription {
+            asyncSubscribeUser {
+                id
+                name
+            }
+        }
+        """
+        
+        let subscriptionResult = try await api.subscribe(
+            request: request,
+            context: api.context,
+            on: group
+        )
+        guard let subscription = subscriptionResult.stream else {
+            XCTFail(subscriptionResult.errors.description)
+            return
+        }
+        guard let stream = subscription as? ConcurrentEventStream else {
+            XCTFail("stream isn't ConcurrentEventStream")
+            return
+        }
+        var iterator = stream.stream.makeAsyncIterator()
+        
+        pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
+        
+        let result = try await iterator.next()?.get()
+        XCTAssertEqual(
+            result,
+            GraphQLResult(data: [
+                "asyncSubscribeUser": [
+                    "id": "124",
+                    "name": "Jerry"
+                ]
+            ])
+        )
+    }
+    
+}
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+/// A very simple publish/subscriber used for testing
+class SimplePubSub<T> {
+    private var subscribers: [Subscriber<T>]
+    
+    init() {
+        subscribers = []
+    }
+    
+    func publish(event: T) {
+        for subscriber in subscribers {
+            subscriber.callback(event)
+        }
+    }
+    
+    func cancel() {
+        for subscriber in subscribers {
+            subscriber.cancel()
+        }
+    }
+    
+    func subscribe() -> ConcurrentEventStream<T> {
+        let asyncStream = AsyncThrowingStream<T, Error> { continuation in
+            let subscriber = Subscriber<T>(
+                callback: { newValue in
+                    continuation.yield(newValue)
+                },
+                cancel: {
+                    continuation.finish()
+                }
+            )
+            subscribers.append(subscriber)
+            return
+        }
+        return ConcurrentEventStream<T>.init(asyncStream)
+    }
+}
+
+struct Subscriber<T> {
+    let callback: (T) -> Void
+    let cancel: () -> Void
+}
+
+#endif

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
@@ -388,3 +388,207 @@ extension HelloWorldTests {
         ]
     }
 }
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+let pubsub = SimplePubSub<User>()
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+extension HelloResolver {
+    func subscribeUser(context: HelloContext, arguments: NoArguments) -> EventStream<User> {
+        pubsub.subscribe()
+    }
+}
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+// Same as the one above, except with a few subscription fields
+struct HelloSubscribeAPI : API {
+    let resolver = HelloResolver()
+    let context = HelloContext()
+    
+    let schema = try! Schema<HelloResolver, HelloContext> {
+        Scalar(Float.self)
+            .description("The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).")
+
+        Scalar(ID.self)
+            .description("The `ID` scalar type represents a unique identifier.")
+        
+        Type(User.self) {
+            Field("id", at: \.id)
+            Field("name", at: \.name)
+            Field("friends", at: \.friends, as: [TypeReference<User>]?.self)
+        }
+
+        Input(UserInput.self) {
+            InputField("id", at: \.id)
+            InputField("name", at: \.name)
+            InputField("friends", at: \.friends, as: [TypeReference<UserInput>]?.self)
+        }
+        
+        Type(UserEvent.self) {
+            Field("user", at: \.user)
+        }
+        
+        Query {
+            Field("hello", at: HelloResolver.hello)
+            Field("asyncHello", at: HelloResolver.asyncHello)
+            
+            Field("float", at: HelloResolver.getFloat) {
+                Argument("float", at: \.float)
+            }
+            
+            Field("id", at: HelloResolver.getId) {
+                Argument("id", at: \.id)
+            }
+            
+            Field("user", at: HelloResolver.getUser)
+        }
+
+        Mutation {
+            Field("addUser", at: HelloResolver.addUser) {
+                Argument("user", at: \.user)
+            }
+        }
+        
+        Subscription {
+            SubscriptionField("subscribeUser", as: User.self, atSub: HelloResolver.subscribeUser)
+            SubscriptionField("subscribeUserEvent", at: User.toEvent, atSub: HelloResolver.subscribeUser)
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+class HelloWorldSubscribeTests : XCTestCase {
+    private let api = HelloSubscribeAPI()
+    private var group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+    
+    /// Tests subscription when the sourceEventStream type matches the resolved type (i.e. the normal resolution function should just short-circuit to the sourceEventStream object)
+    func testSubscriptionSelf() async throws {
+        let request = """
+        subscription {
+            subscribeUser {
+                id
+                name
+            }
+        }
+        """
+        
+        let subscriptionResult = try api.subscribe(
+            request: request,
+            context: api.context,
+            on: group
+        ).wait()
+        guard let subscription = subscriptionResult.stream else {
+            XCTFail(subscriptionResult.errors.description)
+            return
+        }
+        guard let stream = subscription as? ConcurrentEventStream else {
+            XCTFail("stream isn't ConcurrentEventStream")
+            return
+        }
+        var iterator = stream.stream.makeAsyncIterator()
+        
+        pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
+        
+        let result = try await iterator.next()?.get()
+        XCTAssertEqual(
+            result,
+            GraphQLResult(data: [
+                "subscribeUser": [
+                    "id": "124",
+                    "name": "Jerry"
+                ]
+            ])
+        )
+    }
+    
+    /// Tests subscription when the sourceEventStream type does not match the resolved type (i.e. there is a non-trivial resolution function that transforms the sourceEventStream object)
+    func testSubscriptionEvent() async throws {
+        let request = """
+        subscription {
+            subscribeUserEvent {
+                user {
+                    id
+                    name
+                }
+            }
+        }
+        """
+        
+        let subscriptionResult = try api.subscribe(
+            request: request,
+            context: api.context,
+            on: group
+        ).wait()
+        guard let subscription = subscriptionResult.stream else {
+            XCTFail(subscriptionResult.errors.description)
+            return
+        }
+        guard let stream = subscription as? ConcurrentEventStream else {
+            XCTFail("stream isn't ConcurrentEventStream")
+            return
+        }
+        var iterator = stream.stream.makeAsyncIterator()
+        
+        pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
+        
+        let result = try await iterator.next()?.get()
+        XCTAssertEqual(
+            result,
+            GraphQLResult(data: [
+                "subscribeUserEvent": [
+                    "user": [
+                        "id": "124",
+                        "name": "Jerry"
+                    ]
+                ]
+            ])
+        )
+    }
+}
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+/// A very simple publish/subscriber used for testing
+class SimplePubSub<T> {
+    private var subscribers: [Subscriber<T>]
+    
+    init() {
+        subscribers = []
+    }
+    
+    func publish(event: T) {
+        for subscriber in subscribers {
+            subscriber.callback(event)
+        }
+    }
+    
+    func cancel() {
+        for subscriber in subscribers {
+            subscriber.cancel()
+        }
+    }
+    
+    func subscribe() -> ConcurrentEventStream<T> {
+        let asyncStream = AsyncThrowingStream<T, Error> { continuation in
+            let subscriber = Subscriber<T>(
+                callback: { newValue in
+                    continuation.yield(newValue)
+                },
+                cancel: {
+                    continuation.finish()
+                }
+            )
+            subscribers.append(subscriber)
+            return
+        }
+        return ConcurrentEventStream<T>.init(asyncStream)
+    }
+}
+
+struct Subscriber<T> {
+    let callback: (T) -> Void
+    let cancel: () -> Void
+}
+
+#endif


### PR DESCRIPTION
This adds support for Swift concurrency by adding new top-level async public APIs. This includes async versions of `API.execute` and `API.subscribe`, as well as supporting async `Field` and `SubscriptionField` resolver functions.

It also adds subscription tests, which were enabled by adding the Swift concurrency-based `EventStream` in https://github.com/GraphQLSwift/GraphQL/pull/100