### PR TITLE
Fixing HelloWorldAsyncTests and Added missing initializer for SubscriptionField

### DIFF
--- a/Sources/Graphiti/Subscription/SubscribeField.swift
+++ b/Sources/Graphiti/Subscription/SubscribeField.swift
@@ -431,6 +431,28 @@ public extension SubscriptionField where FieldType : Encodable {
     ) {
         self.init(name: name, arguments: arguments(), concurrentResolve: function, concurrentSubscribe: subFunc)
     }
+
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    convenience init(
+        _ name: String,
+        as: FieldType.Type,
+        atSub subFunc: @escaping ConcurrentResolve<ObjectType, Context, Arguments, EventStream<SourceEventType>>,
+        @ArgumentComponentBuilder<Arguments> _ arguments: () -> ArgumentComponent<Arguments>
+    ) {
+
+        self.init(name: name, arguments: [arguments()], as: `as`, concurrentSubscribe: subFunc)
+    }
+
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    convenience init(
+        _ name: String,
+        as: FieldType.Type,
+        atSub subFunc: @escaping ConcurrentResolve<ObjectType, Context, Arguments, EventStream<SourceEventType>>,
+        @ArgumentComponentBuilder<Arguments> _ arguments: () -> [ArgumentComponent<Arguments>] = {[]}
+    ) {
+
+        self.init(name: name, arguments: arguments(), as: `as`, concurrentSubscribe: subFunc)
+    }
 }
 
 public extension SubscriptionField {
@@ -455,6 +477,7 @@ public extension SubscriptionField {
     ) {
         self.init(name: name, arguments: arguments(), concurrentResolve: function, concurrentSubscribe: subFunc)
     }
+
 }
 
 #endif

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
@@ -37,10 +37,12 @@ extension HelloResolver {
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 // Same as the HelloAPI, except with an async query and a few subscription fields
 struct HelloAsyncAPI : API {
-    let resolver = HelloResolver()
-    let context = HelloContext()
+    typealias ContextType = HelloContext
+
+    let resolver: HelloResolver = HelloResolver()
+    let context: HelloContext = HelloContext()
     
-    let schema = try! Schema<HelloResolver, HelloContext> {
+    let schema: Schema<HelloResolver, HelloContext> = try! Schema<HelloResolver, HelloContext> {
         Scalar(Float.self)
             .description("The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).")
 
@@ -91,7 +93,7 @@ struct HelloAsyncAPI : API {
             SubscriptionField("subscribeUserEvent", at: User.toEvent, atSub: HelloResolver.subscribeUser)
             
             SubscriptionField("futureSubscribeUser", as: User.self, atSub: HelloResolver.subscribeUser)
-            SubscriptionField("asyncSubscribeUser", as: User.self, atSub: HelloResolver.subscribeUser)
+            SubscriptionField("asyncSubscribeUser", as: User.self, atSub: HelloResolver.asyncSubscribeUser)
         }
     }
 }


### PR DESCRIPTION
This fixes the `HelloWorldAsyncTests` to actually use the async subscription resolver, `HelloResolver.asyncSubscribeUser`, instead of using `HelloResolver.subscribeUser`. 

This also adds the missing initializer for `SubscriptionField` that takes only the async subscription resolver without the field resolver (`SubscriptionField.init(_:as:atSub:)`)