### PR TITLE
Input Field "as" initializer

### DIFF
--- a/Sources/Graphiti/InputField/InputField.swift
+++ b/Sources/Graphiti/InputField/InputField.swift
@@ -49,6 +49,15 @@ public extension InputField {
     }
 }
 
+public extension InputField {
+    convenience init(
+        _ name: String,
+        as _: FieldType.Type
+    ) {
+        self.init(name: name)
+    }
+}
+
 public extension InputField where FieldType: Encodable {
     func defaultValue(_ defaultValue: FieldType) -> Self {
         self.defaultValue = AnyEncodable(defaultValue)

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
@@ -126,7 +126,7 @@ struct HelloAPI: API {
 
         Input(UserInput.self) {
             InputField("id", at: \.id)
-            InputField("name", at: \.name)
+            InputField("name", as: String?.self)
             InputField("friends", at: \.friends, as: [TypeReference<UserInput>]?.self)
         }
 


### PR DESCRIPTION
This PR adds a new InputField initializer that allows the user to declare the field value type directly (i.e. not using a keypath as a proxy)

The two existing public initializers for InputField require a keypath, which is only used to record the type of the field value. However, in some cases the Swift type backing the Input object may not have keypaths to the input. This is the case with enums.

Here's an example:

```swift
// User can only specify one of a few options. For example, {"option1":"foo"} or {"option2":"bar"},
// but not {"option1":"foo","option2":"bar"}
enum SingleValueInput: Codable {
    case option1(String)
    case option2(String)

    init(from decoder: Decoder) throws {
        let container = try decoder.container(keyedBy: CodingKeys.self)
        let decodedVals: [Self] = [
            try container.decodeIfPresent(Date.self, forKey: .option1).map { .option1($0) },
            try container.decodeIfPresent(Date.self, forKey: .option2).map { .option2($0) },
        ].compactMap { $0 }
        guard decodedVals.count < 2 else {
            throw Error.multipleKeysProvided
        }
        guard let decodedSelf = decodedVals.first else {
            throw Error.noKeyProvided
        }
        self = decodedSelf
    }

    func encode(to encoder: Encoder) throws {
        var container = encoder.container(keyedBy: CodingKeys.self)
        switch self {
        case .option1(let value):
            try container.encode(value, forKey: .option1)
        case .option2(let value):
            try container.encode(value, forKey: .option2)
        }
    }
}

let schema = try Graphiti.Schema<Resolver, Context> {
    ...
    Input(SingleValueInput.self) {
        InputField("option1", as: String?.self)
        InputField("option2", as: String?.self)
    }.description("An input where only one of a few options may be used")
    ...
}
```

In the example above, we couldn't have used the existing initializer like `InputField("option1", at: .option1)` because that's not a valid keypath.
