### PR TITLE
TypeReference Improvements

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,17 @@
         "repositoryURL": "https://github.com/GraphQLSwift/GraphQL.git",
         "state": {
           "branch": null,
-          "revision": "ebd2ea40676f8bcbdfd6088c408f3ed321c1a905",
-          "version": "2.4.0"
+          "revision": "17b96ed859072fca79dd562da2a79e1bc752756f",
+          "version": "2.4.1"
+        }
+      },
+      {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+          "version": "1.0.2"
         }
       },
       {
@@ -15,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections",
         "state": {
           "branch": null,
-          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
-          "version": "1.0.2"
+          "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
+          "version": "1.0.3"
         }
       },
       {
@@ -24,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "124119f0bb12384cef35aa041d7c3a686108722d",
-          "version": "2.40.0"
+          "revision": "a16e2f54a25b2af217044e5168997009a505930f",
+          "version": "2.42.0"
         }
       }
     ]

--- a/Sources/Graphiti/Definition/TypeProvider.swift
+++ b/Sources/Graphiti/Definition/TypeProvider.swift
@@ -56,11 +56,15 @@ extension TypeProvider {
                 return try getGraphQLOptionalType(from: referenceType, isOptional: isOptional)
             }
         } else {
-            guard let graphQLType = graphQLTypeMap[AnyType(type)] else {
-                throw GraphQLError(message: "Type \"\(type)\" is not registered.")
-            }
+            if let graphQLType = graphQLTypeMap[AnyType(type)] {
+                return try getGraphQLOptionalType(from: graphQLType, isOptional: isOptional)
+            } else {
+                // If we haven't seen this type yet, just store it as a type reference and resolve later.
+                let name = Reflection.name(for: type)
+                let referenceType = GraphQLTypeReference(name)
 
-            return try getGraphQLOptionalType(from: graphQLType, isOptional: isOptional)
+                return try getGraphQLOptionalType(from: referenceType, isOptional: isOptional)
+            }
         }
     }
 

--- a/Sources/Graphiti/Enum/Enum.swift
+++ b/Sources/Graphiti/Enum/Enum.swift
@@ -24,6 +24,7 @@ public final class Enum<
         )
 
         try typeProvider.map(EnumType.self, to: enumType)
+        typeProvider.types.append(enumType)
     }
 
     private init(

--- a/Sources/Graphiti/Input/Input.swift
+++ b/Sources/Graphiti/Input/Input.swift
@@ -18,6 +18,7 @@ public final class Input<
         )
 
         try typeProvider.map(InputObjectType.self, to: inputObjectType)
+        typeProvider.types.append(inputObjectType)
     }
 
     func fields(typeProvider: TypeProvider) throws -> InputObjectFieldMap {

--- a/Sources/Graphiti/Interface/Interface.swift
+++ b/Sources/Graphiti/Interface/Interface.swift
@@ -12,6 +12,7 @@ public final class Interface<Resolver, Context, InterfaceType>: Component<Resolv
         )
 
         try typeProvider.map(InterfaceType.self, to: interfaceType)
+        typeProvider.types.append(interfaceType)
     }
 
     func fields(typeProvider: TypeProvider, coders: Coders) throws -> GraphQLFieldMap {

--- a/Sources/Graphiti/Scalar/Scalar.swift
+++ b/Sources/Graphiti/Scalar/Scalar.swift
@@ -34,6 +34,7 @@ open class Scalar<Resolver, Context, ScalarType: Codable>: Component<Resolver, C
         )
 
         try typeProvider.map(ScalarType.self, to: scalarType)
+        typeProvider.types.append(scalarType)
     }
 
     open func serialize(scalar: ScalarType, encoder: MapEncoder) throws -> Map {

--- a/Sources/Graphiti/Type/Type.swift
+++ b/Sources/Graphiti/Type/Type.swift
@@ -20,6 +20,7 @@ public final class Type<Resolver, Context, ObjectType: Encodable>: Component<Res
         )
 
         try typeProvider.map(ObjectType.self, to: objectType)
+        typeProvider.types.append(objectType)
     }
 
     func fields(typeProvider: TypeProvider, coders: Coders) throws -> GraphQLFieldMap {

--- a/Sources/Graphiti/Types/Types.swift
+++ b/Sources/Graphiti/Types/Types.swift
@@ -1,5 +1,6 @@
 import GraphQL
 
+@available(*, deprecated, message: "No longer use this. Instead define types using `Type`.")
 public final class Types<Resolver, Context>: Component<Resolver, Context> {
     let types: [Any.Type]
 
@@ -13,10 +14,8 @@ public final class Types<Resolver, Context>: Component<Resolver, Context> {
         self.types = types
         super.init(name: "")
     }
-}
 
-public extension Types {
-    convenience init(_ types: Any.Type...) {
+    public convenience init(_ types: Any.Type...) {
         self.init(types: types)
     }
 }

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
@@ -61,13 +61,13 @@ import XCTest
             Type(User.self) {
                 Field("id", at: \.id)
                 Field("name", at: \.name)
-                Field("friends", at: \.friends, as: [TypeReference<User>]?.self)
+                Field("friends", at: \.friends)
             }
 
             Input(UserInput.self) {
                 InputField("id", at: \.id)
                 InputField("name", at: \.name)
-                InputField("friends", at: \.friends, as: [TypeReference<UserInput>]?.self)
+                InputField("friends", at: \.friends)
             }
 
             Type(UserEvent.self) {

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
@@ -121,13 +121,13 @@ struct HelloAPI: API {
         Type(User.self) {
             Field("id", at: \.id)
             Field("name", at: \.name)
-            Field("friends", at: \.friends, as: [TypeReference<User>]?.self)
+            Field("friends", at: \.friends)
         }
 
         Input(UserInput.self) {
             InputField("id", at: \.id)
             InputField("name", as: String?.self)
-            InputField("friends", at: \.friends, as: [TypeReference<UserInput>]?.self)
+            InputField("friends", at: \.friends)
         }
 
         Type(UserEvent.self) {

--- a/Tests/GraphitiTests/SchemaTests.swift
+++ b/Tests/GraphitiTests/SchemaTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+@testable import Graphiti
+import GraphQL
+import NIO
+import XCTest
+
+class SchemaTests: XCTestCase {
+    // Tests that circularly dependent objects can be used in schema and resolved correctly
+    func testCircularDependencies() throws {
+        struct A: Codable {
+            let name: String
+            var b: B {
+                B(name: name)
+            }
+        }
+
+        struct B: Codable {
+            let name: String
+            var a: A {
+                A(name: name)
+            }
+        }
+
+        struct TestResolver {
+            func a(context _: NoContext, arguments _: NoArguments) -> A {
+                return A(name: "Circular")
+            }
+        }
+
+        let testSchema = try Schema<TestResolver, NoContext> {
+            Type(A.self) {
+                Field("name", at: \.name)
+                Field("b", at: \.b)
+            }
+            Type(B.self) {
+                Field("name", at: \.name)
+                Field("a", at: \.a)
+            }
+            Query {
+                Field("a", at: TestResolver.a)
+            }
+        }
+        let api = TestAPI<TestResolver, NoContext>(
+            resolver: TestResolver(),
+            schema: testSchema
+        )
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer { try? group.syncShutdownGracefully() }
+
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query {
+                  a {
+                    b {
+                      name
+                    }
+                  }
+                }
+                """,
+                context: NoContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(data: [
+                "a": [
+                    "b": [
+                        "name": "Circular",
+                    ],
+                ],
+            ])
+        )
+    }
+}
+
+private class TestAPI<Resolver, ContextType>: API {
+    public let resolver: Resolver
+    public let schema: Schema<Resolver, ContextType>
+
+    init(resolver: Resolver, schema: Schema<Resolver, ContextType>) {
+        self.resolver = resolver
+        self.schema = schema
+    }
+}

--- a/Tests/GraphitiTests/StarWarsAPI/StarWarsAPI.swift
+++ b/Tests/GraphitiTests/StarWarsAPI/StarWarsAPI.swift
@@ -100,7 +100,5 @@ public struct StarWarsAPI: API {
                     .defaultValue("R2-D2")
             }
         }
-
-        Types(Human.self, Droid.self)
     }
 }

--- a/Tests/GraphitiTests/StarWarsAPI/StarWarsAPI.swift
+++ b/Tests/GraphitiTests/StarWarsAPI/StarWarsAPI.swift
@@ -40,7 +40,7 @@ public struct StarWarsAPI: API {
             Field("diameter", at: \.diameter)
             Field("rotationPeriod", at: \.rotationPeriod)
             Field("orbitalPeriod", at: \.orbitalPeriod)
-            Field("residents", at: \.residents, as: [TypeReference<Human>].self)
+            Field("residents", at: \.residents)
         }
         .description(
             "A large mass, planet or planetoid in the Star Wars Universe, at the time of 0 ABY."

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsQueryTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsQueryTests.swift
@@ -655,8 +655,8 @@ class StarWarsQueryTests: XCTestCase {
 
             let schema = try! Schema<TestResolver, NoContext> {
                 Type(A.self) {
-                    Field("nullableA", at: A.nullableA, as: (TypeReference<A>?).self)
-                    Field("nonNullA", at: A.nonNullA, as: TypeReference<A>.self)
+                    Field("nullableA", at: A.nullableA)
+                    Field("nonNullA", at: A.nonNullA)
                     Field("throws", at: A.throws)
                 }
 


### PR DESCRIPTION
This PR adds enhances TypeReference handling.

When resolving types from the TypeProvider, `GraphQLTypeReference`s are automatically created for any type that is not found, instead of throwing an error. These types are then resolved and enforced during the GraphQL package's schema resolution. The net result is that SchemaBuilder usage of `TypeReference` is much less necessary and there is no longer a requirement that types be defined before they are used in the schema, enabling circular type dependencies.

With these improvements, I've removed unnecessary `TypeReference` usage from the tests. I also deprecated the `Types` construct from the Schema, which seems to be a workaround for TypeReferencing.

Tests were added too.
