### PR TITLE
Fix: Wrapped Aliased Type Resolution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: sinoru/actions-setup-swift@v2
-        with:
-          swift-version: '5.6.1'
+      - uses: swift-actions/setup-swift@v1
       - name: GitHub Action for SwiftFormat
         uses: CassiusPacheco/action-swiftformat@v0.1.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,17 +40,33 @@ jobs:
         coverageCommand: swift test --enable-test-discovery --enable-code-coverage
         coverageLocations: ${{ env.codecov_path }}:lcov-json
 
-  linux:
-    name: Build and test ${{ matrix.swift }} on ${{ matrix.os }}
+  # ubuntu-latest is ubuntu-22.04 currently. Swift versions older than 5.7 don't have builds for 22.04. https://www.swift.org/download/ 
+  ubuntu-old:
+    name: Build ${{ matrix.swift }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04] 
         swift: ["5.4", "5.5", "5.6"]
     steps:
     - uses: swift-actions/setup-swift@v1
       with:
         swift-version: ${{ matrix.swift }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - name: Test
+      run: swift test
+
+  ubuntu-latest:
+    name: Build ${{ matrix.swift }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest] 
+        swift: ["5.7"]
+    steps:
+    - uses: swift-actions/setup-swift@v1
+      with:
+        swift-version: ${{ matrix.swift }}
+    - uses: actions/checkout@v3
     - name: Test
       run: swift test

--- a/Sources/Graphiti/Component/Component.swift
+++ b/Sources/Graphiti/Component/Component.swift
@@ -9,6 +9,7 @@ open class Component<Resolver, Context> {
     }
 
     func update(typeProvider _: SchemaTypeProvider, coders _: Coders) throws {}
+    func setGraphQLName(typeProvider _: SchemaTypeProvider) throws {}
 }
 
 public extension Component {

--- a/Sources/Graphiti/Enum/Enum.swift
+++ b/Sources/Graphiti/Enum/Enum.swift
@@ -27,6 +27,10 @@ public final class Enum<
         typeProvider.types.append(enumType)
     }
 
+    override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {
+        try typeProvider.mapName(EnumType.self, to: name)
+    }
+
     private init(
         type _: EnumType.Type,
         name: String?,

--- a/Sources/Graphiti/Input/Input.swift
+++ b/Sources/Graphiti/Input/Input.swift
@@ -21,6 +21,10 @@ public final class Input<
         typeProvider.types.append(inputObjectType)
     }
 
+    override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {
+        try typeProvider.mapName(InputObjectType.self, to: name)
+    }
+
     func fields(typeProvider: TypeProvider) throws -> InputObjectFieldMap {
         var map: InputObjectFieldMap = [:]
 

--- a/Sources/Graphiti/Interface/Interface.swift
+++ b/Sources/Graphiti/Interface/Interface.swift
@@ -15,6 +15,10 @@ public final class Interface<Resolver, Context, InterfaceType>: Component<Resolv
         typeProvider.types.append(interfaceType)
     }
 
+    override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {
+        try typeProvider.mapName(InterfaceType.self, to: name)
+    }
+
     func fields(typeProvider: TypeProvider, coders: Coders) throws -> GraphQLFieldMap {
         var map: GraphQLFieldMap = [:]
 

--- a/Sources/Graphiti/Scalar/Scalar.swift
+++ b/Sources/Graphiti/Scalar/Scalar.swift
@@ -37,6 +37,10 @@ open class Scalar<Resolver, Context, ScalarType: Codable>: Component<Resolver, C
         typeProvider.types.append(scalarType)
     }
 
+    override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {
+        try typeProvider.mapName(ScalarType.self, to: name)
+    }
+
     open func serialize(scalar: ScalarType, encoder: MapEncoder) throws -> Map {
         try encoder.encode(scalar)
     }

--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -10,6 +10,12 @@ public final class Schema<Resolver, Context> {
     ) throws {
         let typeProvider = SchemaTypeProvider()
 
+        // Collect types mappings first
+        for component in components {
+            try component.setGraphQLName(typeProvider: typeProvider)
+        }
+
+        // Then build up GraphQLTypes
         for component in components {
             try component.update(typeProvider: typeProvider, coders: coders)
         }

--- a/Sources/Graphiti/Schema/SchemaTypeProvider.swift
+++ b/Sources/Graphiti/Schema/SchemaTypeProvider.swift
@@ -1,6 +1,13 @@
 import GraphQL
 
 final class SchemaTypeProvider: TypeProvider {
+    var graphQLNameMap: [AnyType: String] = [
+        AnyType(Int.self): "Int",
+        AnyType(Double.self): "Float",
+        AnyType(String.self): "String",
+        AnyType(Bool.self): "Boolean",
+    ]
+
     var graphQLTypeMap: [AnyType: GraphQLType] = [
         AnyType(Int.self): GraphQLInt,
         AnyType(Double.self): GraphQLFloat,

--- a/Sources/Graphiti/Type/Type.swift
+++ b/Sources/Graphiti/Type/Type.swift
@@ -23,6 +23,10 @@ public final class Type<Resolver, Context, ObjectType: Encodable>: Component<Res
         typeProvider.types.append(objectType)
     }
 
+    override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {
+        try typeProvider.mapName(ObjectType.self, to: name)
+    }
+
     func fields(typeProvider: TypeProvider, coders: Coders) throws -> GraphQLFieldMap {
         var map: GraphQLFieldMap = [:]
 

--- a/Sources/Graphiti/Union/Union.swift
+++ b/Sources/Graphiti/Union/Union.swift
@@ -16,6 +16,10 @@ public final class Union<Resolver, Context, UnionType>: Component<Resolver, Cont
         try typeProvider.map(UnionType.self, to: unionType)
     }
 
+    override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {
+        try typeProvider.mapName(UnionType.self, to: name)
+    }
+
     init(
         type _: UnionType.Type,
         name: String? = nil,

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
@@ -5,10 +5,10 @@ import XCTest
 
 #if compiler(>=5.5) && canImport(_Concurrency)
 
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     let pubsub = SimplePubSub<User>()
 
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     extension HelloResolver {
         func asyncHello(
             context: HelloContext,
@@ -41,7 +41,7 @@ import XCTest
         }
     }
 
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     // Same as the HelloAPI, except with an async query and a few subscription fields
     struct HelloAsyncAPI: API {
         typealias ContextType = HelloContext
@@ -122,7 +122,7 @@ import XCTest
         }
     }
 
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     class HelloWorldAsyncTests: XCTestCase {
         private let api = HelloAsyncAPI()
         private var group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
@@ -320,7 +320,7 @@ import XCTest
         }
     }
 
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
     /// A very simple publish/subscriber used for testing
     class SimplePubSub<T> {
         private var subscribers: [Subscriber<T>]


### PR DESCRIPTION
This fixes https://github.com/GraphQLSwift/Graphiti/issues/41

This added a collection of all SwiftTypes and their aliased GraphQL names to TypeProvider. These names are collected before any GraphQL types are created, and are used when resolving TypeReferences, so out-of-order references to aliased types are no longer mis-addressed.

To do so, we had to add a `setGraphQLName` function to the Component class, and implementations for all GraphQL Type components (Enum, Input, Interface, Scalar, Schema, Type, and Union). Schema construction now goes through all components to collect names prior to building up the GraphQL schema objects.