### PR TITLE
add array based init for unions

### DIFF
--- a/Sources/Graphiti/Union/Union.swift
+++ b/Sources/Graphiti/Union/Union.swift
@@ -38,4 +38,12 @@ public extension Union {
     ) {
         self.init(type: type, name: name, members: members)
     }
+
+    convenience init(
+        _ type: UnionType.Type,
+        as name: String? = nil,
+        members: [Any.Type]
+    ) {
+        self.init(type: type, name: name, members: members)
+    }
 }

--- a/Tests/GraphitiTests/UnionTests.swift
+++ b/Tests/GraphitiTests/UnionTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+@testable import Graphiti
+import GraphQL
+import NIO
+import XCTest
+
+class UnionTests: XCTestCase {
+    func testUnionInit() throws {
+        _ = try Schema<StarWarsResolver, StarWarsContext> {
+            Type(Planet.self) {
+                Field("id", at: \.id)
+            }
+
+            Type(Human.self) {
+                Field("id", at: \.id)
+            }
+
+            Type(Droid.self) {
+                Field("id", at: \.id)
+            }
+
+            Union(SearchResult.self, members: Planet.self, Human.self, Droid.self)
+
+            Query {
+                Field("search", at: StarWarsResolver.search, as: [SearchResult].self) {
+                    Argument("query", at: \.query)
+                }
+            }
+        }
+
+
+        _ = try Schema<StarWarsResolver, StarWarsContext> {
+            Type(Planet.self) {
+                Field("id", at: \.id)
+            }
+
+            Type(Human.self) {
+                Field("id", at: \.id)
+            }
+
+            Type(Droid.self) {
+                Field("id", at: \.id)
+            }
+
+            Union(SearchResult.self, members: [
+                Planet.self,
+                Human.self,
+                Droid.self,
+            ])
+
+            Query {
+                Field("search", at: StarWarsResolver.search, as: [SearchResult].self) {
+                    Argument("query", at: \.query)
+                }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
For unions with a lot of members it's sometimes easier to format the code so each member is on a new line with a trailing comma. You can't do this with the variadic style init. 