### PR TITLE
Declarative Partial Schema

### DIFF
--- a/Sources/Graphiti/Definition/TypeProvider.swift
+++ b/Sources/Graphiti/Definition/TypeProvider.swift
@@ -255,7 +255,7 @@ extension TypeProvider {
 
         return objectType
     }
-    
+
     private func getGraphQLName(of type: Any.Type) -> String {
         return graphQLNameMap[AnyType(type)] ?? Reflection.name(for: type)
     }

--- a/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
+++ b/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
@@ -1,0 +1,40 @@
+/// A partial schema that declare a set of type, query, mutation, and/or subscription definition
+/// which can be compiled together into 1 schema.
+open class PartialSchema<Resolver, Context> {
+    /// A custom parameter attribute that constructs type definitions from closures.
+    public typealias TypeDefinitions = TypeComponentBuilder<Resolver, Context>
+
+    /// A custom parameter attribute that constructs operation field definitions from closures.
+    public typealias FieldDefinitions = FieldComponentBuilder<Resolver, Context>
+
+    /// A type that represents a set of type definitions
+    public typealias Types = [TypeComponent<Resolver, Context>]
+
+    /// A type that represents a set of operation field definitions
+    public typealias Fields = [FieldComponent<Resolver, Context>]
+
+    /// Definitions of types
+    open var types: Types { [] }
+
+    /// Definitions of query operation fields
+    open var query: Fields { [] }
+
+    /// Definitions of mutation operation fields
+    open var mutation: Fields { [] }
+
+    /// Definitions of subscription operation fields
+    open var subscription: Fields { [] }
+
+    public init() {}
+}
+
+public extension Schema {
+    /// Create a schema from partial schemas
+    /// - Parameter partials: Partial schemas that declare types, query, mutation, and/or subscription definiton
+    /// - Returns: A compiled schema will all definitions given from the partial schemas
+    static func create(from partials: [PartialSchema<Resolver, Context>]) throws -> Schema<Resolver, Context> {
+        try SchemaBuilder(Resolver.self, Context.self)
+            .use(partials: partials)
+            .build()
+    }
+}

--- a/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
+++ b/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
@@ -32,7 +32,9 @@ public extension Schema {
     /// Create a schema from partial schemas
     /// - Parameter partials: Partial schemas that declare types, query, mutation, and/or subscription definiton
     /// - Returns: A compiled schema will all definitions given from the partial schemas
-    static func create(from partials: [PartialSchema<Resolver, Context>]) throws -> Schema<Resolver, Context> {
+    static func create(
+        from partials: [PartialSchema<Resolver, Context>]
+    ) throws -> Schema<Resolver, Context> {
         try SchemaBuilder(Resolver.self, Context.self)
             .use(partials: partials)
             .build()

--- a/Sources/Graphiti/SchemaBuilders/SchemaBuilder.swift
+++ b/Sources/Graphiti/SchemaBuilders/SchemaBuilder.swift
@@ -104,6 +104,26 @@ public final class SchemaBuilder<Resolver, Context> {
         return self
     }
 
+    @discardableResult
+    /// Adds multiple type, query, mutation, and subscription definitions using partial schemas to the schema.
+    /// - Parameter partials: Partial schemas that declare types, query, mutation, and/or subscription definiton
+    /// - Returns: Thie object for method chaining
+    public func use(partials: [PartialSchema<Resolver, Context>]) -> Self {
+        for type in partials.flatMap({ $0.types }) {
+            typeComponents.append(type)
+        }
+        for query in partials.flatMap({ $0.query }) {
+            queryFields.append(query)
+        }
+        for mutation in partials.flatMap({ $0.mutation }) {
+            mutationFields.append(mutation)
+        }
+        for subscription in partials.flatMap({ $0.subscription }) {
+            subscriptionFields.append(subscription)
+        }        
+        return self
+    }
+
     /// Create and return the queryable GraphQL schema
     public func build() throws -> Schema<Resolver, Context> {
         var components = typeComponents.map { topLevelComponent in

--- a/Sources/Graphiti/SchemaBuilders/SchemaBuilder.swift
+++ b/Sources/Graphiti/SchemaBuilders/SchemaBuilder.swift
@@ -11,12 +11,12 @@ public final class SchemaBuilder<Resolver, Context> {
     private var subscriptionFields: [FieldComponent<Resolver, Context>]
 
     public init(
-        _ resolverType: Resolver.Type,
-        _ contextType: Context.Type
+        _: Resolver.Type,
+        _: Context.Type
     ) {
         coders = Coders()
         typeComponents = []
-        
+
         queryName = "Query"
         queryFields = []
         mutationName = "Mutation"
@@ -33,19 +33,19 @@ public final class SchemaBuilder<Resolver, Context> {
         coders = newCoders
         return self
     }
-    
+
     @discardableResult
     public func setQueryName(to name: String) -> Self {
         queryName = name
         return self
     }
-    
+
     @discardableResult
     public func setMutationName(to name: String) -> Self {
         mutationName = name
         return self
     }
-    
+
     @discardableResult
     public func setSubscriptionName(to name: String) -> Self {
         subscriptionName = name
@@ -57,49 +57,53 @@ public final class SchemaBuilder<Resolver, Context> {
     /// - Parameter component: The query operations to add
     /// - Returns: This object for method chaining
     public func add(
-        @TypeComponentBuilder<Resolver, Context> _ components: () -> [TypeComponent<Resolver, Context>]
+        @TypeComponentBuilder<Resolver, Context> _ components: ()
+            -> [TypeComponent<Resolver, Context>]
     ) -> Self {
         for component in components() {
             typeComponents.append(component)
         }
         return self
     }
-    
+
     @discardableResult
     /// Adds multiple query operation definitions to the schema.
     /// - Parameter component: The query operations to add
     /// - Returns: This object for method chaining
     public func addQuery(
-        @FieldComponentBuilder<Resolver, Context> _ fields: () -> [FieldComponent<Resolver, Context>]
+        @FieldComponentBuilder<Resolver, Context> _ fields: ()
+            -> [FieldComponent<Resolver, Context>]
     ) -> Self {
         for field in fields() {
-            self.queryFields.append(field)
+            queryFields.append(field)
         }
         return self
     }
-    
+
     @discardableResult
     /// Adds multiple mutation operation definitions to the schema.
     /// - Parameter component: The query operations to add
     /// - Returns: This object for method chaining
     public func addMutation(
-        @FieldComponentBuilder<Resolver, Context> _ fields: () -> [FieldComponent<Resolver, Context>]
+        @FieldComponentBuilder<Resolver, Context> _ fields: ()
+            -> [FieldComponent<Resolver, Context>]
     ) -> Self {
         for field in fields() {
-            self.mutationFields.append(field)
+            mutationFields.append(field)
         }
         return self
     }
-    
+
     @discardableResult
     /// Adds multiple subscription operation definitions to the schema.
     /// - Parameter component: The query operations to add
     /// - Returns: This object for method chaining
     public func addSubscription(
-        @FieldComponentBuilder<Resolver, Context> _ fields: () -> [FieldComponent<Resolver, Context>]
+        @FieldComponentBuilder<Resolver, Context> _ fields: ()
+            -> [FieldComponent<Resolver, Context>]
     ) -> Self {
         for field in fields() {
-            self.subscriptionFields.append(field)
+            subscriptionFields.append(field)
         }
         return self
     }
@@ -120,7 +124,7 @@ public final class SchemaBuilder<Resolver, Context> {
         }
         for subscription in partials.flatMap({ $0.subscription }) {
             subscriptionFields.append(subscription)
-        }        
+        }
         return self
     }
 

--- a/Tests/GraphitiTests/PartialSchemaTests.swift
+++ b/Tests/GraphitiTests/PartialSchemaTests.swift
@@ -1,0 +1,167 @@
+import Graphiti
+import GraphQL
+import NIO
+import XCTest
+
+class PartialSchemaTests: XCTestCase {
+    class BaseSchema: PartialSchema<StarWarsResolver, StarWarsContext> {
+        @TypeDefinitions
+        override var types: Types {
+            Interface(Character.self) {
+                Field("id", at: \.id)
+                    .description("The id of the character.")
+                Field("name", at: \.name)
+                    .description("The name of the character.")
+                Field("friends", at: \.friends, as: [TypeReference<Character>].self)
+                    .description(
+                        "The friends of the character, or an empty list if they have none."
+                    )
+                Field("appearsIn", at: \.appearsIn)
+                    .description("Which movies they appear in.")
+                Field("secretBackstory", at: \.secretBackstory)
+                    .description("All secrets about their past.")
+            }
+
+            Enum(Episode.self) {
+                Value(.newHope)
+                    .description("Released in 1977.")
+                Value(.empire)
+                    .description("Released in 1980.")
+                Value(.jedi)
+                    .description("Released in 1983.")
+            }.description("One of the films in the Star Wars Trilogy.")
+        }
+
+        @FieldDefinitions
+        override var query: Fields {
+            Field("hero", at: StarWarsResolver.hero, as: Character.self) {
+                Argument("episode", at: \.episode)
+                    .description(
+                        "If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode."
+                    )
+            }.description("Returns a hero based on the given episode.")
+        }
+    }
+
+    class SearchSchema: PartialSchema<StarWarsResolver, StarWarsContext> {
+        @TypeDefinitions
+        override var types: Types {
+            Type(Planet.self) {
+                Field("id", at: \.id)
+                Field("name", at: \.name)
+                Field("diameter", at: \.diameter)
+                Field("rotationPeriod", at: \.rotationPeriod)
+                Field("orbitalPeriod", at: \.orbitalPeriod)
+                Field("residents", at: \.residents)
+            }.description(
+                "A large mass, planet or planetoid in the Star Wars Universe, at the time of 0 ABY."
+            )
+            Type(Human.self, interfaces: [Character.self]) {
+                Field("id", at: \.id)
+                Field("name", at: \.name)
+                Field("appearsIn", at: \.appearsIn)
+                Field("homePlanet", at: \.homePlanet)
+                Field("friends", at: Human.getFriends, as: [Character].self)
+                    .description("The friends of the human, or an empty list if they have none.")
+                Field("secretBackstory", at: Human.getSecretBackstory)
+                    .description("Where are they from and how they came to be who they are.")
+            }.description("A humanoid creature in the Star Wars universe.")
+            Type(Droid.self, interfaces: [Character.self]) {
+                Field("id", at: \.id)
+                Field("name", at: \.name)
+                Field("appearsIn", at: \.appearsIn)
+                Field("primaryFunction", at: \.primaryFunction)
+                Field("friends", at: Droid.getFriends, as: [Character].self)
+                    .description("The friends of the droid, or an empty list if they have none.")
+                Field("secretBackstory", at: Droid.getSecretBackstory)
+                    .description("Where are they from and how they came to be who they are.")
+            }.description("A mechanical creature in the Star Wars universe.")
+            Union(SearchResult.self, members: Planet.self, Human.self, Droid.self)
+        }
+
+        @FieldDefinitions
+        override var query: Fields {
+            Field("human", at: StarWarsResolver.human) {
+                Argument("id", at: \.id)
+                    .description("Id of the human.")
+            }
+            Field("droid", at: StarWarsResolver.droid) {
+                Argument("id", at: \.id)
+                    .description("Id of the droid.")
+            }
+            Field("search", at: StarWarsResolver.search, as: [SearchResult].self) {
+                Argument("query", at: \.query)
+                    .defaultValue("R2-D2")
+            }
+        }
+    }
+
+    func testPartialSchemaWithBuilder() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+
+        let builder = SchemaBuilder(StarWarsResolver.self, StarWarsContext.self)
+
+        builder.use(partials: [BaseSchema(), SearchSchema()])
+
+        let schema = try builder.build()
+
+        struct PartialSchemaTestAPI: API {
+            let resolver: StarWarsResolver
+            let schema: Schema<StarWarsResolver, StarWarsContext>
+        }
+        
+        let api = PartialSchemaTestAPI(resolver: StarWarsResolver(), schema: schema)
+
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query {
+                    human(id: "1000") {
+                        name
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(data: [
+                "human": [
+                    "name": "Luke Skywalker",
+                ],
+            ])
+        )
+    }
+
+    func testPartialSchema() throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+
+        /// Double check if static func works and the types are inferred properly
+        let schema = try Schema.create(from: [BaseSchema(), SearchSchema()])
+
+        struct PartialSchemaTestAPI: API {
+            let resolver: StarWarsResolver
+            let schema: Schema<StarWarsResolver, StarWarsContext>
+        }
+        
+        let api = PartialSchemaTestAPI(resolver: StarWarsResolver(), schema: schema)
+
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query {
+                    human(id: "1000") {
+                        name
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(data: [
+                "human": [
+                    "name": "Luke Skywalker",
+                ],
+            ])
+        )
+    }
+}

--- a/Tests/GraphitiTests/PartialSchemaTests.swift
+++ b/Tests/GraphitiTests/PartialSchemaTests.swift
@@ -109,7 +109,7 @@ class PartialSchemaTests: XCTestCase {
             let resolver: StarWarsResolver
             let schema: Schema<StarWarsResolver, StarWarsContext>
         }
-        
+
         let api = PartialSchemaTestAPI(resolver: StarWarsResolver(), schema: schema)
 
         XCTAssertEqual(
@@ -142,7 +142,7 @@ class PartialSchemaTests: XCTestCase {
             let resolver: StarWarsResolver
             let schema: Schema<StarWarsResolver, StarWarsContext>
         }
-        
+
         let api = PartialSchemaTestAPI(resolver: StarWarsResolver(), schema: schema)
 
         XCTAssertEqual(

--- a/Tests/GraphitiTests/SchemaBuilderTests.swift
+++ b/Tests/GraphitiTests/SchemaBuilderTests.swift
@@ -94,12 +94,12 @@ class SchemaBuilderTests: XCTestCase {
         }
 
         let schema = try builder.build()
-        
+
         struct SchemaBuilderTestAPI: API {
             let resolver: StarWarsResolver
             let schema: Schema<StarWarsResolver, StarWarsContext>
         }
-        
+
         let api = SchemaBuilderTestAPI(resolver: StarWarsResolver(), schema: schema)
 
         XCTAssertEqual(

--- a/Tests/GraphitiTests/UnionTests.swift
+++ b/Tests/GraphitiTests/UnionTests.swift
@@ -28,7 +28,6 @@ class UnionTests: XCTestCase {
             }
         }
 
-
         _ = try Schema<StarWarsResolver, StarWarsContext> {
             Type(Planet.self) {
                 Field("id", at: \.id)
@@ -54,6 +53,5 @@ class UnionTests: XCTestCase {
                 }
             }
         }
-
     }
 }


### PR DESCRIPTION
## Changes overview
- Adds a class that allow for a declarative way to create schemas from multiple partial / sub schemas. 
- Extends SchemaBuilder to take in PartialSchema classes
- Extends Schema with a way to create one from a list of PartialSchema

## Example

```swift
class AuthSchema: PartialSchema<Resolver, Context> {
    @TypesDefinitions
    override var types: Types {
        Type(User.self) {
            Field("id", at: \.id)
            Field("name", at: \.name)
            Field("email", at: \.email)
            Field("orders", at: User.orders, as: [TypeReference<Order>].self)
        }
        Type(Credential.self) {
            Field("token", at: \.token)
            Field("expiresAt", at: \.expiresAt)
            Field("user", at: \.user)
        }
    }

    @FieldDefinitions
    override var query: Fields {
        Field("me", at: Resolver.me)
    }

    @FieldDefinitions
    override var mutation: Fields {
        Field("login", at: Resolver.login)
        Field("signup", at: Resolver.signup)
    }
}

class OrderSchema: PartialSchema<Resolver, Context> {
    @TypesDefinitions
    override var types: Types {
        Type(Order.self) {
            Field("id", at: \.id)
            Field("quantity", at: \.quantity)
            Field("cost", at: \.cost)
            Field("user", at: Order.user)
            Field("status", at: Order.currentStatus, as: TypeReference<Status>?.self)
            Field("progress", at: Order.progress, as: [TypeReference<Status>].self)
        }
        Type(Status.self) {
            Field("distance", at: \.distance)
            Field("progress", at: \.progress)
            Field("order", at: Status.order)
        }
    }

    @FieldDefinitions
    override var query: Fields {
        Field("order", at: Resolver.orderById) {
            Argument("id", at: \.id)
        }
    }

    @FieldDefinitions
    override var mutation: Fields {
        Field("createOrder", at: Resolver.createOrder) {
            Argument("quantity", at: \.quantity)
        }
    }
}

let schema = try Schema.create(from: [AuthSchema(), OrderSchema()])
```

## Related issue
Addresses #85 

## Naming
I landed on the name PartialSchema, but I don't mind changing it to something better if anyone had better names. 

## Limitation
I implemented this using classes to allow usage of this new feature from any version of Swift. I had another working implementation using strictly protocols but that require primary associated types and the `any` keyword which is only available in Swift 5.7