### PR TITLE
Fix: interface and union ordering

### DIFF
--- a/Sources/Graphiti/Component/Component.swift
+++ b/Sources/Graphiti/Component/Component.swift
@@ -3,9 +3,11 @@ import GraphQL
 open class Component<Resolver, Context> {
     let name: String
     var description: String?
+    var componentType: ComponentType
 
-    init(name: String) {
+    init(name: String, type: ComponentType) {
         self.name = name
+        self.componentType = type
     }
 
     func update(typeProvider _: SchemaTypeProvider, coders _: Coders) throws {}
@@ -16,5 +18,43 @@ public extension Component {
     func description(_ description: String) -> Self {
         self.description = description
         return self
+    }
+}
+
+/// The type of a component. This is used as opposed to runtime type-checking because the
+/// component types are typically generics (and therefore hard to type-check).
+enum ComponentType {
+    case none
+    case connection
+    case `enum`
+    case input
+    case interface
+    case mutation
+    case query
+    case scalar
+    case subscription
+    case type
+    case types
+    case union
+    
+    /// An index used to sort components into the correct schema build order. This order goes
+    /// from "least other type references" to "most". By building in this order we are able to satisfy
+    /// hard ordering requirements (interfaces MUST be built before inheriting types), as well as
+    /// reduce unnecessary TypeReferences.
+    var buildOrder: Int {
+        switch self {
+        case .none: return 0
+        case .scalar: return 1
+        case .enum: return 2
+        case .interface: return 3
+        case .input: return 4
+        case .type: return 5
+        case .types: return 6
+        case .union: return 7
+        case .connection: return 8
+        case .query: return 9
+        case .mutation: return 10
+        case .subscription: return 11
+        }
     }
 }

--- a/Sources/Graphiti/Component/Component.swift
+++ b/Sources/Graphiti/Component/Component.swift
@@ -7,7 +7,7 @@ open class Component<Resolver, Context> {
 
     init(name: String, type: ComponentType) {
         self.name = name
-        self.componentType = type
+        componentType = type
     }
 
     func update(typeProvider _: SchemaTypeProvider, coders _: Coders) throws {}
@@ -36,7 +36,7 @@ enum ComponentType {
     case type
     case types
     case union
-    
+
     /// An index used to sort components into the correct schema build order. This order goes
     /// from "least other type references" to "most". By building in this order we are able to satisfy
     /// hard ordering requirements (interfaces MUST be built before inheriting types), as well as

--- a/Sources/Graphiti/Connection/ConnectionType.swift
+++ b/Sources/Graphiti/Connection/ConnectionType.swift
@@ -45,7 +45,10 @@ public final class ConnectionType<
         type _: ObjectType.Type,
         name: String?
     ) {
-        super.init(name: name ?? Reflection.name(for: ObjectType.self))
+        super.init(
+            name: name ?? Reflection.name(for: ObjectType.self),
+            type: .connection
+        )
     }
 }
 

--- a/Sources/Graphiti/Connection/ConnectionType.swift
+++ b/Sources/Graphiti/Connection/ConnectionType.swift
@@ -22,7 +22,7 @@ public final class ConnectionType<
 
         let edge = Type<Resolver, Context, Edge<ObjectType>>(
             Edge<ObjectType>.self,
-            as: name+"Edge"
+            as: name + "Edge"
         ) {
             Field("node", at: \.node)
             Field("cursor", at: \.cursor)
@@ -32,7 +32,7 @@ public final class ConnectionType<
 
         let connection = Type<Resolver, Context, Connection<ObjectType>>(
             Connection<ObjectType>.self,
-            as: name+"Connection"
+            as: name + "Connection"
         ) {
             Field("edges", at: \.edges)
             Field("pageInfo", at: \.pageInfo)

--- a/Sources/Graphiti/Enum/Enum.swift
+++ b/Sources/Graphiti/Enum/Enum.swift
@@ -23,8 +23,7 @@ public final class Enum<
             }
         )
 
-        try typeProvider.map(EnumType.self, to: enumType)
-        typeProvider.types.append(enumType)
+        try typeProvider.add(type: EnumType.self, as: enumType)
     }
 
     override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {

--- a/Sources/Graphiti/Enum/Enum.swift
+++ b/Sources/Graphiti/Enum/Enum.swift
@@ -36,7 +36,10 @@ public final class Enum<
         values: [Value<EnumType>]
     ) {
         self.values = values
-        super.init(name: name ?? Reflection.name(for: EnumType.self))
+        super.init(
+            name: name ?? Reflection.name(for: EnumType.self),
+            type: .enum
+        )
     }
 }
 

--- a/Sources/Graphiti/Input/Input.swift
+++ b/Sources/Graphiti/Input/Input.swift
@@ -17,8 +17,7 @@ public final class Input<
             fields: fields(typeProvider: typeProvider)
         )
 
-        try typeProvider.map(InputObjectType.self, to: inputObjectType)
-        typeProvider.types.append(inputObjectType)
+        try typeProvider.add(type: InputObjectType.self, as: inputObjectType)
     }
 
     override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {

--- a/Sources/Graphiti/Input/Input.swift
+++ b/Sources/Graphiti/Input/Input.swift
@@ -41,7 +41,10 @@ public final class Input<
         fields: [InputFieldComponent<InputObjectType, Context>]
     ) {
         self.fields = fields
-        super.init(name: name ?? Reflection.name(for: InputObjectType.self))
+        super.init(
+            name: name ?? Reflection.name(for: InputObjectType.self),
+            type: .connection
+        )
     }
 }
 

--- a/Sources/Graphiti/Interface/Interface.swift
+++ b/Sources/Graphiti/Interface/Interface.swift
@@ -14,8 +14,7 @@ public final class Interface<Resolver, Context, InterfaceType>: TypeComponent<
             resolveType: nil
         )
 
-        try typeProvider.map(InterfaceType.self, to: interfaceType)
-        typeProvider.types.append(interfaceType)
+        try typeProvider.add(type: InterfaceType.self, as: interfaceType)
     }
 
     override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {

--- a/Sources/Graphiti/Interface/Interface.swift
+++ b/Sources/Graphiti/Interface/Interface.swift
@@ -38,7 +38,10 @@ public final class Interface<Resolver, Context, InterfaceType>: TypeComponent<
         fields: [FieldComponent<InterfaceType, Context>]
     ) {
         self.fields = fields
-        super.init(name: name ?? Reflection.name(for: InterfaceType.self))
+        super.init(
+            name: name ?? Reflection.name(for: InterfaceType.self),
+            type: .interface
+        )
     }
 }
 

--- a/Sources/Graphiti/Mutation/Mutation.swift
+++ b/Sources/Graphiti/Mutation/Mutation.swift
@@ -32,7 +32,10 @@ public final class Mutation<Resolver, Context>: Component<Resolver, Context> {
         fields: [FieldComponent<Resolver, Context>]
     ) {
         self.fields = fields
-        super.init(name: name)
+        super.init(
+            name: name,
+            type: .mutation
+        )
     }
 }
 

--- a/Sources/Graphiti/Query/Query.swift
+++ b/Sources/Graphiti/Query/Query.swift
@@ -32,7 +32,10 @@ public final class Query<Resolver, Context>: Component<Resolver, Context> {
         fields: [FieldComponent<Resolver, Context>]
     ) {
         self.fields = fields
-        super.init(name: name)
+        super.init(
+            name: name,
+            type: .query
+        )
     }
 }
 

--- a/Sources/Graphiti/Scalar/Scalar.swift
+++ b/Sources/Graphiti/Scalar/Scalar.swift
@@ -52,7 +52,10 @@ open class Scalar<Resolver, Context, ScalarType: Codable>: TypeComponent<Resolve
         type _: ScalarType.Type,
         name: String?
     ) {
-        super.init(name: name ?? Reflection.name(for: ScalarType.self))
+        super.init(
+            name: name ?? Reflection.name(for: ScalarType.self),
+            type: .scalar
+        )
     }
 }
 

--- a/Sources/Graphiti/Scalar/Scalar.swift
+++ b/Sources/Graphiti/Scalar/Scalar.swift
@@ -33,8 +33,7 @@ open class Scalar<Resolver, Context, ScalarType: Codable>: TypeComponent<Resolve
             }
         )
 
-        try typeProvider.map(ScalarType.self, to: scalarType)
-        typeProvider.types.append(scalarType)
+        try typeProvider.add(type: ScalarType.self, as: scalarType)
     }
 
     override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {

--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -14,9 +14,12 @@ public final class Schema<Resolver, Context> {
         for component in components {
             try component.setGraphQLName(typeProvider: typeProvider)
         }
-
-        // Then build up GraphQLTypes
-        for component in components {
+        
+        // Order component by componentType build order
+        let sortedComponents = components.sorted {
+            $0.componentType.buildOrder <= $1.componentType.buildOrder
+        }
+        for component in sortedComponents {
             try component.update(typeProvider: typeProvider, coders: coders)
         }
 

--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -14,7 +14,7 @@ public final class Schema<Resolver, Context> {
         for component in components {
             try component.setGraphQLName(typeProvider: typeProvider)
         }
-        
+
         // Order component by componentType build order
         let sortedComponents = components.sorted {
             $0.componentType.buildOrder <= $1.componentType.buildOrder

--- a/Sources/Graphiti/Schema/SchemaTypeProvider.swift
+++ b/Sources/Graphiti/Schema/SchemaTypeProvider.swift
@@ -20,9 +20,9 @@ final class SchemaTypeProvider: TypeProvider {
     var subscription: GraphQLObjectType?
     var types: [GraphQLNamedType] = []
     var directives: [GraphQLDirective] = []
-    
+
     func add(type: Any.Type, as graphQLType: GraphQLNamedType) throws {
-        try self.map(type, to: graphQLType)
+        try map(type, to: graphQLType)
         types.append(graphQLType)
     }
 }

--- a/Sources/Graphiti/Schema/SchemaTypeProvider.swift
+++ b/Sources/Graphiti/Schema/SchemaTypeProvider.swift
@@ -20,4 +20,9 @@ final class SchemaTypeProvider: TypeProvider {
     var subscription: GraphQLObjectType?
     var types: [GraphQLNamedType] = []
     var directives: [GraphQLDirective] = []
+    
+    func add(type: Any.Type, as graphQLType: GraphQLNamedType) throws {
+        try self.map(type, to: graphQLType)
+        types.append(graphQLType)
+    }
 }

--- a/Sources/Graphiti/Subscription/Subscription.swift
+++ b/Sources/Graphiti/Subscription/Subscription.swift
@@ -32,7 +32,10 @@ public final class Subscription<Resolver, Context>: Component<Resolver, Context>
         fields: [FieldComponent<Resolver, Context>]
     ) {
         self.fields = fields
-        super.init(name: name)
+        super.init(
+            name: name,
+            type: .subscription
+        )
     }
 }
 

--- a/Sources/Graphiti/Type/Type.swift
+++ b/Sources/Graphiti/Type/Type.swift
@@ -22,8 +22,7 @@ public final class Type<Resolver, Context, ObjectType: Encodable>: TypeComponent
             isTypeOf: isTypeOf
         )
 
-        try typeProvider.map(ObjectType.self, to: objectType)
-        typeProvider.types.append(objectType)
+        try typeProvider.add(type: ObjectType.self, as: objectType)
     }
 
     override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {

--- a/Sources/Graphiti/Type/Type.swift
+++ b/Sources/Graphiti/Type/Type.swift
@@ -48,7 +48,10 @@ public final class Type<Resolver, Context, ObjectType: Encodable>: TypeComponent
     ) {
         self.interfaces = interfaces
         self.fields = fields
-        super.init(name: name ?? Reflection.name(for: ObjectType.self))
+        super.init(
+            name: name ?? Reflection.name(for: ObjectType.self),
+            type: .type
+        )
     }
 }
 

--- a/Sources/Graphiti/Types/Types.swift
+++ b/Sources/Graphiti/Types/Types.swift
@@ -12,7 +12,10 @@ public final class Types<Resolver, Context>: Component<Resolver, Context> {
 
     init(types: [Any.Type]) {
         self.types = types
-        super.init(name: "")
+        super.init(
+            name: "",
+            type: .types
+        )
     }
 
     public convenience init(_ types: Any.Type...) {

--- a/Sources/Graphiti/Union/Union.swift
+++ b/Sources/Graphiti/Union/Union.swift
@@ -14,6 +14,7 @@ public final class Union<Resolver, Context, UnionType>: TypeComponent<Resolver, 
         )
 
         try typeProvider.map(UnionType.self, to: unionType)
+        typeProvider.types.append(unionType)
     }
 
     override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {

--- a/Sources/Graphiti/Union/Union.swift
+++ b/Sources/Graphiti/Union/Union.swift
@@ -13,8 +13,7 @@ public final class Union<Resolver, Context, UnionType>: TypeComponent<Resolver, 
             }
         )
 
-        try typeProvider.map(UnionType.self, to: unionType)
-        typeProvider.types.append(unionType)
+        try typeProvider.add(type: UnionType.self, as: unionType)
     }
 
     override func setGraphQLName(typeProvider: SchemaTypeProvider) throws {

--- a/Sources/Graphiti/Union/Union.swift
+++ b/Sources/Graphiti/Union/Union.swift
@@ -26,7 +26,10 @@ public final class Union<Resolver, Context, UnionType>: TypeComponent<Resolver, 
         members: [Any.Type]
     ) {
         self.members = members
-        super.init(name: name ?? Reflection.name(for: UnionType.self))
+        super.init(
+            name: name ?? Reflection.name(for: UnionType.self),
+            type: .union
+        )
     }
 }
 

--- a/Tests/GraphitiTests/PartialSchemaTests.swift
+++ b/Tests/GraphitiTests/PartialSchemaTests.swift
@@ -166,35 +166,35 @@ class PartialSchemaTests: XCTestCase {
     }
 
     func testPartialSchemaOutOfOrder() throws {
-    let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
-    /// Double check if ordering of partial schema doesn't matter
-    let schema = try Schema.create(from: [SearchSchema(), BaseSchema()])
+        /// Double check if ordering of partial schema doesn't matter
+        let schema = try Schema.create(from: [SearchSchema(), BaseSchema()])
 
-    struct PartialSchemaTestAPI: API {
-        let resolver: StarWarsResolver
-        let schema: Schema<StarWarsResolver, StarWarsContext>
-    }
+        struct PartialSchemaTestAPI: API {
+            let resolver: StarWarsResolver
+            let schema: Schema<StarWarsResolver, StarWarsContext>
+        }
 
-    let api = PartialSchemaTestAPI(resolver: StarWarsResolver(), schema: schema)
+        let api = PartialSchemaTestAPI(resolver: StarWarsResolver(), schema: schema)
 
-    XCTAssertEqual(
-        try api.execute(
-            request: """
-            query {
-                human(id: "1000") {
-                    name
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query {
+                    human(id: "1000") {
+                        name
+                    }
                 }
-            }
-            """,
-            context: StarWarsContext(),
-            on: group
-        ).wait(),
-        GraphQLResult(data: [
-            "human": [
-                "name": "Luke Skywalker",
-            ],
-        ])
-    )
-}
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(data: [
+                "human": [
+                    "name": "Luke Skywalker",
+                ],
+            ])
+        )
+    }
 }

--- a/Tests/GraphitiTests/SchemaBuilderTests.swift
+++ b/Tests/GraphitiTests/SchemaBuilderTests.swift
@@ -122,7 +122,7 @@ class SchemaBuilderTests: XCTestCase {
                 ],
             ])
         )
-        
+
         XCTAssert(
             api.schema.schema.typeMap.contains(where: { key, _ in
                 key == "PlanetConnection"

--- a/Tests/GraphitiTests/SchemaBuilderTests.swift
+++ b/Tests/GraphitiTests/SchemaBuilderTests.swift
@@ -42,20 +42,7 @@ class SchemaBuilderTests: XCTestCase {
             }.description("One of the films in the Star Wars Trilogy.")
         }
         builder.add {
-            Interface(Character.self) {
-                Field("id", at: \.id)
-                    .description("The id of the character.")
-                Field("name", at: \.name)
-                    .description("The name of the character.")
-                Field("friends", at: \.friends, as: [TypeReference<Character>].self)
-                    .description(
-                        "The friends of the character, or an empty list if they have none."
-                    )
-                Field("appearsIn", at: \.appearsIn)
-                    .description("Which movies they appear in.")
-                Field("secretBackstory", at: \.secretBackstory)
-                    .description("All secrets about their past.")
-            }
+            Union(SearchResult.self, members: Planet.self, Human.self, Droid.self)
         }.add {
             Type(Human.self, interfaces: [Character.self]) {
                 Field("id", at: \.id)
@@ -78,7 +65,20 @@ class SchemaBuilderTests: XCTestCase {
                     .description("Where are they from and how they came to be who they are.")
             }.description("A mechanical creature in the Star Wars universe.")
         }.add {
-            Union(SearchResult.self, members: Planet.self, Human.self, Droid.self)
+            Interface(Character.self) {
+                Field("id", at: \.id)
+                    .description("The id of the character.")
+                Field("name", at: \.name)
+                    .description("The name of the character.")
+                Field("friends", at: \.friends, as: [TypeReference<Character>].self)
+                    .description(
+                        "The friends of the character, or an empty list if they have none."
+                    )
+                Field("appearsIn", at: \.appearsIn)
+                    .description("Which movies they appear in.")
+                Field("secretBackstory", at: \.secretBackstory)
+                    .description("All secrets about their past.")
+            }
         }
         builder.addQuery {
             Field("human", at: StarWarsResolver.human) {


### PR DESCRIPTION
This fixes the following bugs:

1. Interface no longer must be declared before any inheriting types
2. Unions are correctly added to the GraphQL schema

Fixes https://github.com/GraphQLSwift/Graphiti/issues/96