### PR TITLE
Instance-based PartialSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,12 @@ let api = MessageAPI(
 
 Schemas may also be created in a modular way using `SchemaBuilder`:
 
-```
+<blockquote>
+
+<details open="true">
+<summary>SchemaBuilder API</summary>
+
+```swift
 let builder = SchemaBuilder(Resolver.self, Context.self)
 builder.add(
     Type(Message.self) {
@@ -120,6 +125,66 @@ let api = MessageAPI(
     schema: schema
 )
 ``` 
+
+</details>
+<details>
+<summary>PartialSchema implementation</summary>
+
+```swift
+final class ChatSchema: PartialSchema<Resolver, Context> {
+    @TypeDefinitions
+    public override var types: Types {
+        Type(Message.self) {
+            Field("content", at: \.content)
+        }        
+    }
+
+    @FieldDefinitions
+    public override var query: Fields {
+        Field("message", at: Resolver.message)
+    }
+}
+let schema = try SchemaBuilder(Resolver.self, Context.self)
+    .use(partials: [ChatSchema(), ...])
+    .build()
+
+let api = MessageAPI(
+    resolver: Resolver()
+    schema: schema
+)
+``` 
+
+</details>
+
+<details>
+<summary>PartialSchema instance</summary>
+
+```swift
+let chatSchema = PartialSchema<Resolver, Context>(
+    types:  {
+        Type(Message.self) {
+            Field("content", at: \.content)
+        }        
+    },
+    query: {
+        Field("message", at: Resolver.message)
+    }
+)
+let schema = try SchemaBuilder(Resolver.self, Context.self)
+    .use(partials: [chatSchema, ...])
+    .build()
+
+let api = MessageAPI(
+    resolver: Resolver()
+    schema: schema
+)
+``` 
+
+</details>
+
+---
+
+</blockquote>
 
 ⭐️ Notice that `API` allows dependency injection. You could pass mocks of `resolver` and `context` when testing, for example.
 

--- a/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
+++ b/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
@@ -13,7 +13,6 @@ open class PartialSchema<Resolver, Context> {
     /// A type that represents a set of operation field definitions
     public typealias Fields = [FieldComponent<Resolver, Context>]
 
-
     /// Stored predefined "default" properties for a instance-based declaration
     private let tdef: Types
     private let qdef: Fields
@@ -26,12 +25,11 @@ open class PartialSchema<Resolver, Context> {
         @FieldDefinitions mutation: () -> Fields = { [] },
         @FieldDefinitions subscription: () -> Fields = { [] }
     ) {
-        self.tdef = types()
-        self.qdef = query();
-        self.mdef = mutation()
-        self.sdef = subscription()
+        tdef = types()
+        qdef = query()
+        mdef = mutation()
+        sdef = subscription()
     }
-
 
     /// Definitions of types
     open var types: Types { tdef }

--- a/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
+++ b/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
@@ -13,19 +13,37 @@ open class PartialSchema<Resolver, Context> {
     /// A type that represents a set of operation field definitions
     public typealias Fields = [FieldComponent<Resolver, Context>]
 
+
+    /// Stored predefined "default" properties for a instance-based declaration
+    private let tdef: Types
+    private let qdef: Fields
+    private let mdef: Fields
+    private let sdef: Fields
+
+    public init(
+        @TypeDefinitions types: () -> Types = { [] },
+        @FieldDefinitions query: () -> Fields = { [] },
+        @FieldDefinitions mutation: () -> Fields = { [] },
+        @FieldDefinitions subscription: () -> Fields = { [] }
+    ) {
+        self.tdef = types()
+        self.qdef = query();
+        self.mdef = mutation()
+        self.sdef = subscription()
+    }
+
+
     /// Definitions of types
-    open var types: Types { [] }
+    open var types: Types { tdef }
 
     /// Definitions of query operation fields
-    open var query: Fields { [] }
+    open var query: Fields { qdef }
 
     /// Definitions of mutation operation fields
-    open var mutation: Fields { [] }
+    open var mutation: Fields { mdef }
 
     /// Definitions of subscription operation fields
-    open var subscription: Fields { [] }
-
-    public init() {}
+    open var subscription: Fields { sdef }
 }
 
 public extension Schema {

--- a/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
+++ b/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
@@ -14,10 +14,10 @@ open class PartialSchema<Resolver, Context> {
     public typealias Fields = [FieldComponent<Resolver, Context>]
 
     /// Stored predefined "default" properties for a instance-based declaration
-    private let tdef: Types
-    private let qdef: Fields
-    private let mdef: Fields
-    private let sdef: Fields
+    private let typedef: Types
+    private let querydef: Fields
+    private let mutationdef: Fields
+    private let subscriptiondef: Fields
 
     public init(
         @TypeDefinitions types: () -> Types = { [] },
@@ -25,23 +25,23 @@ open class PartialSchema<Resolver, Context> {
         @FieldDefinitions mutation: () -> Fields = { [] },
         @FieldDefinitions subscription: () -> Fields = { [] }
     ) {
-        tdef = types()
-        qdef = query()
-        mdef = mutation()
-        sdef = subscription()
+        typedef = types()
+        querydef = query()
+        mutationdef = mutation()
+        subscriptiondef = subscription()
     }
 
     /// Definitions of types
-    open var types: Types { tdef }
+    open var types: Types { typedef }
 
     /// Definitions of query operation fields
-    open var query: Fields { qdef }
+    open var query: Fields { querydef }
 
     /// Definitions of mutation operation fields
-    open var mutation: Fields { mdef }
+    open var mutation: Fields { mutationdef }
 
     /// Definitions of subscription operation fields
-    open var subscription: Fields { sdef }
+    open var subscription: Fields { subscriptiondef }
 }
 
 public extension Schema {

--- a/Tests/GraphitiTests/PartialSchemaTests.swift
+++ b/Tests/GraphitiTests/PartialSchemaTests.swift
@@ -235,7 +235,7 @@ class PartialSchemaTests: XCTestCase {
                         .description("Released in 1980.")
                     Value(.jedi)
                         .description("Released in 1983.")
-                }.description("One of the films in the Star Wars Trilogy.")  
+                }.description("One of the films in the Star Wars Trilogy.")
             },
             query: {
                 Field("hero", at: StarWarsResolver.hero, as: Character.self) {
@@ -265,7 +265,9 @@ class PartialSchemaTests: XCTestCase {
                     Field("appearsIn", at: \.appearsIn)
                     Field("homePlanet", at: \.homePlanet)
                     Field("friends", at: Human.getFriends, as: [Character].self)
-                        .description("The friends of the human, or an empty list if they have none.")
+                        .description(
+                            "The friends of the human, or an empty list if they have none."
+                        )
                     Field("secretBackstory", at: Human.getSecretBackstory)
                         .description("Where are they from and how they came to be who they are.")
                 }.description("A humanoid creature in the Star Wars universe.")
@@ -275,7 +277,9 @@ class PartialSchemaTests: XCTestCase {
                     Field("appearsIn", at: \.appearsIn)
                     Field("primaryFunction", at: \.primaryFunction)
                     Field("friends", at: Droid.getFriends, as: [Character].self)
-                        .description("The friends of the droid, or an empty list if they have none.")
+                        .description(
+                            "The friends of the droid, or an empty list if they have none."
+                        )
                     Field("secretBackstory", at: Droid.getSecretBackstory)
                         .description("Where are they from and how they came to be who they are.")
                 }.description("A mechanical creature in the Star Wars universe.")

--- a/Tests/GraphitiTests/PartialSchemaTests.swift
+++ b/Tests/GraphitiTests/PartialSchemaTests.swift
@@ -99,6 +99,10 @@ class PartialSchemaTests: XCTestCase {
     func testPartialSchemaWithBuilder() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
+        defer {
+            try? group.syncShutdownGracefully()
+        }
+
         let builder = SchemaBuilder(StarWarsResolver.self, StarWarsContext.self)
 
         builder.use(partials: [BaseSchema(), SearchSchema()])
@@ -135,6 +139,10 @@ class PartialSchemaTests: XCTestCase {
     func testPartialSchema() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
+        defer {
+            try? group.syncShutdownGracefully()
+        }
+
         /// Double check if static func works and the types are inferred properly
         let schema = try Schema.create(from: [BaseSchema(), SearchSchema()])
 
@@ -168,8 +176,135 @@ class PartialSchemaTests: XCTestCase {
     func testPartialSchemaOutOfOrder() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
+        defer {
+            try? group.syncShutdownGracefully()
+        }
+
         /// Double check if ordering of partial schema doesn't matter
         let schema = try Schema.create(from: [SearchSchema(), BaseSchema()])
+
+        struct PartialSchemaTestAPI: API {
+            let resolver: StarWarsResolver
+            let schema: Schema<StarWarsResolver, StarWarsContext>
+        }
+
+        let api = PartialSchemaTestAPI(resolver: StarWarsResolver(), schema: schema)
+
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query {
+                    human(id: "1000") {
+                        name
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(data: [
+                "human": [
+                    "name": "Luke Skywalker",
+                ],
+            ])
+        )
+    }
+
+    func testInstancePartialSchema() throws {
+        let baseSchema = PartialSchema<StarWarsResolver, StarWarsContext>(
+            types: {
+                Interface(Character.self) {
+                    Field("id", at: \.id)
+                        .description("The id of the character.")
+                    Field("name", at: \.name)
+                        .description("The name of the character.")
+                    Field("friends", at: \.friends, as: [TypeReference<Character>].self)
+                        .description(
+                            "The friends of the character, or an empty list if they have none."
+                        )
+                    Field("appearsIn", at: \.appearsIn)
+                        .description("Which movies they appear in.")
+                    Field("secretBackstory", at: \.secretBackstory)
+                        .description("All secrets about their past.")
+                }
+
+                Enum(Episode.self) {
+                    Value(.newHope)
+                        .description("Released in 1977.")
+                    Value(.empire)
+                        .description("Released in 1980.")
+                    Value(.jedi)
+                        .description("Released in 1983.")
+                }.description("One of the films in the Star Wars Trilogy.")  
+            },
+            query: {
+                Field("hero", at: StarWarsResolver.hero, as: Character.self) {
+                    Argument("episode", at: \.episode)
+                        .description(
+                            "If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode."
+                        )
+                }.description("Returns a hero based on the given episode.")
+            }
+        )
+
+        let searchSchema = PartialSchema<StarWarsResolver, StarWarsContext>(
+            types: {
+                Type(Planet.self) {
+                    Field("id", at: \.id)
+                    Field("name", at: \.name)
+                    Field("diameter", at: \.diameter)
+                    Field("rotationPeriod", at: \.rotationPeriod)
+                    Field("orbitalPeriod", at: \.orbitalPeriod)
+                    Field("residents", at: \.residents)
+                }.description(
+                    "A large mass, planet or planetoid in the Star Wars Universe, at the time of 0 ABY."
+                )
+                Type(Human.self, interfaces: [Character.self]) {
+                    Field("id", at: \.id)
+                    Field("name", at: \.name)
+                    Field("appearsIn", at: \.appearsIn)
+                    Field("homePlanet", at: \.homePlanet)
+                    Field("friends", at: Human.getFriends, as: [Character].self)
+                        .description("The friends of the human, or an empty list if they have none.")
+                    Field("secretBackstory", at: Human.getSecretBackstory)
+                        .description("Where are they from and how they came to be who they are.")
+                }.description("A humanoid creature in the Star Wars universe.")
+                Type(Droid.self, interfaces: [Character.self]) {
+                    Field("id", at: \.id)
+                    Field("name", at: \.name)
+                    Field("appearsIn", at: \.appearsIn)
+                    Field("primaryFunction", at: \.primaryFunction)
+                    Field("friends", at: Droid.getFriends, as: [Character].self)
+                        .description("The friends of the droid, or an empty list if they have none.")
+                    Field("secretBackstory", at: Droid.getSecretBackstory)
+                        .description("Where are they from and how they came to be who they are.")
+                }.description("A mechanical creature in the Star Wars universe.")
+                Union(SearchResult.self, members: Planet.self, Human.self, Droid.self)
+            },
+            query: {
+                Field("human", at: StarWarsResolver.human) {
+                    Argument("id", at: \.id)
+                        .description("Id of the human.")
+                }
+                Field("droid", at: StarWarsResolver.droid) {
+                    Argument("id", at: \.id)
+                        .description("Id of the droid.")
+                }
+                Field("search", at: StarWarsResolver.search, as: [SearchResult].self) {
+                    Argument("query", at: \.query)
+                        .defaultValue("R2-D2")
+                }
+            }
+        )
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+
+        defer {
+            try? group.syncShutdownGracefully()
+        }
+
+        /// Double check if ordering of partial schema doesn't matter
+        let schema = try Schema.create(from: [searchSchema, baseSchema])
 
         struct PartialSchemaTestAPI: API {
             let resolver: StarWarsResolver


### PR DESCRIPTION
> **Note**
> This is a lower priority change, it doesn't need to be merged right away

## Changes overview
- Allow the use of instance to declare PartialSchema which is more closely aligned with how Schema is used

## Reasoning
Subclassing declaration would have more boilerplate than Instance based declaration

## Example

```swift 
let AuthSchema = PartialSchema<Resolver, Context>(
    types: {
        Type(User.self) {
            Field("id", at: \.id)
            Field("name", at: \.name)
            Field("email", at: \.email)
            Field("orders", at: User.orders, as: [TypeReference<Order>].self)
        }
        Type(Credential.self) {
            Field("token", at: \.token)
            Field("expiresAt", at: \.expiresAt)
            Field("user", at: \.user)
        }
    },
    query: {
        Field("me", at: Resolver.me)
    },
    mutation: {
        Field("login", at: Resolver.login)
        Field("signup", at: Resolver.signup)
    }
)

let OrderSchema = PartialSchema<Resolver, Context>(
    types: {
        Type(Order.self) {
            Field("id", at: \.id)
            Field("quantity", at: \.quantity)
            Field("cost", at: \.cost)
            Field("user", at: Order.user)
            Field("status", at: Order.currentStatus, as: TypeReference<Status>?.self)
            Field("progress", at: Order.progress, as: [TypeReference<Status>].self)
        }
        Type(Status.self) {
            Field("distance", at: \.distance)
            Field("progress", at: \.progress)
            Field("order", at: Status.order)
        }
    },
    query: {
        Field("order", at: Resolver.orderById) {
            Argument("id", at: \.id)
        }
    },
    mutation: {
        Field("createOrder", at: Resolver.createOrder) {
            Argument("quantity", at: \.quantity)
        }
    }
)

let schema = try Schema.create(from: [AuthSchema, OrderSchema])
```