### PR TITLE
Fix: Federation Introspection

### DIFF
--- a/Sources/Graphiti/Federation/Queries.swift
+++ b/Sources/Graphiti/Federation/Queries.swift
@@ -18,7 +18,7 @@ func entitiesQuery(for federatedTypes: [GraphQLObjectType], entityType: GraphQLU
     return GraphQLField(
         type: GraphQLNonNull(GraphQLList(entityType)),
         description: "Return all entities matching the provided representations.",
-        args: ["representations": GraphQLArgument(type: GraphQLList(anyType))],
+        args: ["representations": GraphQLArgument(type: GraphQLNonNull(GraphQLList(GraphQLNonNull(anyType))))],
         resolve: { source, args, context, eventLoopGroup, info in
             let arguments = try coders.decoder.decode(EntityArguments.self, from: args)
             let futures: [EventLoopFuture<Any?>] = try arguments.representations.map { (representationMap: Map) in

--- a/Sources/Graphiti/Federation/Queries.swift
+++ b/Sources/Graphiti/Federation/Queries.swift
@@ -1,8 +1,6 @@
 import GraphQL
 import NIO
 
-let resolveReferenceFieldName = "__resolveReference"
-
 func serviceQuery(for sdl: String) -> GraphQLField {
     return GraphQLField(
         type: GraphQLNonNull(serviceType),
@@ -14,7 +12,11 @@ func serviceQuery(for sdl: String) -> GraphQLField {
     )
 }
 
-func entitiesQuery(for federatedTypes: [GraphQLObjectType], entityType: GraphQLUnionType, coders: Coders) -> GraphQLField {
+func entitiesQuery(
+    for federatedResolvers: [String: GraphQLFieldResolve],
+    entityType: GraphQLUnionType,
+    coders: Coders
+) -> GraphQLField {
     return GraphQLField(
         type: GraphQLNonNull(GraphQLList(entityType)),
         description: "Return all entities matching the provided representations.",
@@ -26,13 +28,8 @@ func entitiesQuery(for federatedTypes: [GraphQLObjectType], entityType: GraphQLU
                     EntityRepresentation.self,
                     from: representationMap
                 )
-                guard let type = federatedTypes.first(where: { value in value.name == representation.__typename }) else {
+                guard let resolve = federatedResolvers[representation.__typename] else {
                     throw GraphQLError(message: "Federated type not found: \(representation.__typename)")
-                }
-                guard let resolve = type.fields[resolveReferenceFieldName]?.resolve else {
-                    throw GraphQLError(
-                        message: "Federated type has no '__resolveReference' field resolver: \(type.name)"
-                    )
                 }
                 return try resolve(
                     source,

--- a/Sources/Graphiti/Query/Query.swift
+++ b/Sources/Graphiti/Query/Query.swift
@@ -24,7 +24,11 @@ public final class Query<Resolver, Context>: Component<Resolver, Context> {
             typeProvider.types.append(entity)
             
             // Add subgraph queries (_entities, _service)
-            queryFields["_entities"] = entitiesQuery(for: federatedTypes, entityType: entity, coders: coders)
+            queryFields["_entities"] = entitiesQuery(
+                for: typeProvider.federatedResolvers,
+                entityType: entity,
+                coders: coders
+            )
             queryFields["_service"] = serviceQuery(for: sdl)
         }
         

--- a/Sources/Graphiti/Schema/SchemaTypeProvider.swift
+++ b/Sources/Graphiti/Schema/SchemaTypeProvider.swift
@@ -28,9 +28,4 @@ final class SchemaTypeProvider: TypeProvider {
         try map(type, to: graphQLType)
         types.append(graphQLType)
     }
-    
-    func addFederated(type: Any.Type, as graphQLType: GraphQLObjectType) throws {
-        try add(type: type, as: graphQLType)
-        federatedTypes.append(graphQLType)
-    }
 }

--- a/Sources/Graphiti/Schema/SchemaTypeProvider.swift
+++ b/Sources/Graphiti/Schema/SchemaTypeProvider.swift
@@ -16,6 +16,7 @@ final class SchemaTypeProvider: TypeProvider {
     ]
     
     var federatedTypes: [GraphQLObjectType] = []
+    var federatedResolvers: [String: GraphQLFieldResolve] = [:]
     var federatedSDL: String? = nil
 
     var query: GraphQLObjectType?

--- a/Sources/Graphiti/Type/Type.swift
+++ b/Sources/Graphiti/Type/Type.swift
@@ -29,7 +29,7 @@ public final class Type<Resolver, Context, ObjectType: Encodable>: TypeComponent
                 type: GraphQLNonNull(GraphQLTypeReference(name)), // Self-referential
                 description: "Return the entity of this object type that matches the provided representation.  Used by Query._entities.",
                 args: [
-                    "representations": GraphQLArgument(type: GraphQLList(anyType))
+                    "representation": GraphQLArgument(type: GraphQLNonNull(anyType))
                 ],
                 resolve: { source, args, context, eventLoopGroup, info in
                     guard let s = source as? Resolver else {


### PR DESCRIPTION
This tweaks the federation implementation to avoid creating `__resolveReference` fields on each entity. Instead, the appropriate entity resolver function is generated, stored, and referenced outside the GraphQL object itself. This avoids polluting the GraphQL object with unnecessary fields.