### PR TITLE
Schema validation rules

### DIFF
--- a/Sources/Graphiti/API/API.swift
+++ b/Sources/Graphiti/API/API.swift
@@ -6,20 +6,16 @@ public protocol API {
     associatedtype ContextType
     var resolver: Resolver { get }
     var schema: Schema<Resolver, ContextType> { get }
-    var validationRules: [(ValidationContext) -> Visitor] { get }
 }
 
 public extension API {
-    var validationRules: [(ValidationContext) -> Visitor] {
-        []
-    }
-    
     func execute(
         request: String,
         context: ContextType,
         on eventLoopGroup: EventLoopGroup,
         variables: [String: Map] = [:],
-        operationName: String? = nil
+        operationName: String? = nil,
+        validationRules: [(ValidationContext) -> Visitor] = []
     ) -> EventLoopFuture<GraphQLResult> {
         return schema.execute(
             request: request,
@@ -37,7 +33,8 @@ public extension API {
         context: ContextType,
         on eventLoopGroup: EventLoopGroup,
         variables: [String: Map] = [:],
-        operationName: String? = nil
+        operationName: String? = nil,
+        validationRules: [(ValidationContext) -> Visitor] = []
     ) -> EventLoopFuture<SubscriptionResult> {
         return schema.subscribe(
             request: request,
@@ -60,7 +57,8 @@ public extension API {
             context: ContextType,
             on eventLoopGroup: EventLoopGroup,
             variables: [String: Map] = [:],
-            operationName: String? = nil
+            operationName: String? = nil,
+            validationRules: [(ValidationContext) -> Visitor] = []
         ) async throws -> GraphQLResult {
             return try await schema.execute(
                 request: request,
@@ -79,7 +77,8 @@ public extension API {
             context: ContextType,
             on eventLoopGroup: EventLoopGroup,
             variables: [String: Map] = [:],
-            operationName: String? = nil
+            operationName: String? = nil,
+            validationRules: [(ValidationContext) -> Visitor] = []
         ) async throws -> SubscriptionResult {
             return try await schema.subscribe(
                 request: request,

--- a/Sources/Graphiti/API/API.swift
+++ b/Sources/Graphiti/API/API.swift
@@ -6,9 +6,14 @@ public protocol API {
     associatedtype ContextType
     var resolver: Resolver { get }
     var schema: Schema<Resolver, ContextType> { get }
+    var validationRules: [(ValidationContext) -> Visitor] { get }
 }
 
 public extension API {
+    var validationRules: [(ValidationContext) -> Visitor] {
+        []
+    }
+    
     func execute(
         request: String,
         context: ContextType,
@@ -22,7 +27,8 @@ public extension API {
             context: context,
             eventLoopGroup: eventLoopGroup,
             variables: variables,
-            operationName: operationName
+            operationName: operationName,
+            validationRules: validationRules
         )
     }
 
@@ -39,7 +45,8 @@ public extension API {
             context: context,
             eventLoopGroup: eventLoopGroup,
             variables: variables,
-            operationName: operationName
+            operationName: operationName,
+            validationRules: validationRules
         )
     }
 }
@@ -61,7 +68,8 @@ public extension API {
                 context: context,
                 eventLoopGroup: eventLoopGroup,
                 variables: variables,
-                operationName: operationName
+                operationName: operationName,
+                validationRules: validationRules
             ).get()
         }
 
@@ -79,7 +87,8 @@ public extension API {
                 context: context,
                 eventLoopGroup: eventLoopGroup,
                 variables: variables,
-                operationName: operationName
+                operationName: operationName,
+                validationRules: validationRules
             ).get()
         }
     }

--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -74,7 +74,7 @@ public extension Schema {
     ) -> EventLoopFuture<GraphQLResult> {
         do {
             return try graphql(
-                validationRules: validationRules,
+                validationRules: GraphQL.specifiedRules + validationRules,
                 schema: schema,
                 request: request,
                 rootValue: resolver,
@@ -99,7 +99,7 @@ public extension Schema {
     ) -> EventLoopFuture<SubscriptionResult> {
         do {
             return try graphqlSubscribe(
-                validationRules: validationRules,
+                validationRules: GraphQL.specifiedRules + validationRules,
                 schema: schema,
                 request: request,
                 rootValue: resolver,

--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -69,10 +69,12 @@ public extension Schema {
         context: Context,
         eventLoopGroup: EventLoopGroup,
         variables: [String: Map] = [:],
-        operationName: String? = nil
+        operationName: String? = nil,
+        validationRules: [(ValidationContext) -> Visitor] = []
     ) -> EventLoopFuture<GraphQLResult> {
         do {
             return try graphql(
+                validationRules: validationRules,
                 schema: schema,
                 request: request,
                 rootValue: resolver,
@@ -92,10 +94,12 @@ public extension Schema {
         context: Context,
         eventLoopGroup: EventLoopGroup,
         variables: [String: Map] = [:],
-        operationName: String? = nil
+        operationName: String? = nil,
+        validationRules: [(ValidationContext) -> Visitor] = []
     ) -> EventLoopFuture<SubscriptionResult> {
         do {
             return try graphqlSubscribe(
+                validationRules: validationRules,
                 schema: schema,
                 request: request,
                 rootValue: resolver,

--- a/Sources/Graphiti/Validation/NoIntrospectionRule.swift
+++ b/Sources/Graphiti/Validation/NoIntrospectionRule.swift
@@ -1,0 +1,10 @@
+import GraphQL
+
+public func NoIntrospectionRule(context: ValidationContext) -> Visitor {
+    return Visitor(enter: { node, _, _, _, _ in
+        if let field = node as? GraphQL.Field, ["__schema", "__type"].contains(field.name.value) {
+            context.report(error: .init(message: "GraphQL introspection is not allowed, but the query contained __schema or __type", nodes: [node]))
+        }
+        return .continue
+    })
+}

--- a/Tests/GraphitiTests/ValidationRulesTests.swift
+++ b/Tests/GraphitiTests/ValidationRulesTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+@testable import Graphiti
+import GraphQL
+import NIO
+import XCTest
+
+class ValidationRulesTests: XCTestCase {
+    // Tests that circularly dependent objects can be used in schema and resolved correctly
+    func testRegisteringCustomValidationRule() throws {
+        struct TestResolver {
+            var helloWorld: String { "Hellow World" }
+        }
+        
+        let testSchema = try Schema<TestResolver, NoContext> {
+            Query {
+                Field("helloWorld", at: \.helloWorld)
+            }
+        }
+        let api = TestAPI<TestResolver, NoContext>(
+            resolver: TestResolver(),
+            schema: testSchema,
+            validationRules: GraphQL.specifiedRules + [disableIntrospectionValidation(context:)]
+        )
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer { try? group.syncShutdownGracefully() }
+
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query {
+                  __type(name: "Query") {
+                      name
+                      description
+                    }
+                }
+                """,
+                context: NoContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(errors: [
+                .init(message: "GraphQL introspection is not allowed, but the query contained __schema or __type", locations: [.init(line: 2, column: 3)])
+            ])
+        )
+    }
+}
+
+
+func disableIntrospectionValidation(context: ValidationContext) -> Visitor {
+    return Visitor(enter: { node, _, _, _, _ in
+        if let field = node as? GraphQL.Field, ["__schema", "__type"].contains(field.name.value) {
+            context.report(error: .init(message: "GraphQL introspection is not allowed, but the query contained __schema or __type", nodes: [node]))
+        }
+        return .continue
+    })
+}
+
+private class TestAPI<Resolver, ContextType>: API {
+    public let resolver: Resolver
+    public let schema: Schema<Resolver, ContextType>
+    var validationRules: [(ValidationContext) -> Visitor]
+
+    init(resolver: Resolver, schema: Schema<Resolver, ContextType>, validationRules: [(ValidationContext) -> Visitor]) {
+        self.resolver = resolver
+        self.schema = schema
+        self.validationRules = validationRules
+    }
+}

--- a/Tests/GraphitiTests/ValidationRulesTests.swift
+++ b/Tests/GraphitiTests/ValidationRulesTests.swift
@@ -19,7 +19,7 @@ class ValidationRulesTests: XCTestCase {
         let api = TestAPI<TestResolver, NoContext>(
             resolver: TestResolver(),
             schema: testSchema,
-            validationRules: GraphQL.specifiedRules + [disableIntrospectionValidation(context:)]
+            validationRules: GraphQL.specifiedRules + [NoIntrospectionRule]
         )
 
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
@@ -43,16 +43,6 @@ class ValidationRulesTests: XCTestCase {
             ])
         )
     }
-}
-
-
-func disableIntrospectionValidation(context: ValidationContext) -> Visitor {
-    return Visitor(enter: { node, _, _, _, _ in
-        if let field = node as? GraphQL.Field, ["__schema", "__type"].contains(field.name.value) {
-            context.report(error: .init(message: "GraphQL introspection is not allowed, but the query contained __schema or __type", nodes: [node]))
-        }
-        return .continue
-    })
 }
 
 private class TestAPI<Resolver, ContextType>: API {

--- a/Tests/GraphitiTests/ValidationRulesTests.swift
+++ b/Tests/GraphitiTests/ValidationRulesTests.swift
@@ -18,8 +18,7 @@ class ValidationRulesTests: XCTestCase {
         }
         let api = TestAPI<TestResolver, NoContext>(
             resolver: TestResolver(),
-            schema: testSchema,
-            validationRules: GraphQL.specifiedRules + [NoIntrospectionRule]
+            schema: testSchema
         )
 
         let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
@@ -36,7 +35,8 @@ class ValidationRulesTests: XCTestCase {
                 }
                 """,
                 context: NoContext(),
-                on: group
+                on: group,
+                validationRules: [NoIntrospectionRule]
             ).wait(),
             GraphQLResult(errors: [
                 .init(message: "GraphQL introspection is not allowed, but the query contained __schema or __type", locations: [.init(line: 2, column: 3)])
@@ -48,11 +48,9 @@ class ValidationRulesTests: XCTestCase {
 private class TestAPI<Resolver, ContextType>: API {
     public let resolver: Resolver
     public let schema: Schema<Resolver, ContextType>
-    var validationRules: [(ValidationContext) -> Visitor]
 
-    init(resolver: Resolver, schema: Schema<Resolver, ContextType>, validationRules: [(ValidationContext) -> Visitor]) {
+    init(resolver: Resolver, schema: Schema<Resolver, ContextType>) {
         self.resolver = resolver
         self.schema = schema
-        self.validationRules = validationRules
     }
 }

--- a/Tests/GraphitiTests/ValidationRulesTests.swift
+++ b/Tests/GraphitiTests/ValidationRulesTests.swift
@@ -5,7 +5,7 @@ import NIO
 import XCTest
 
 class ValidationRulesTests: XCTestCase {
-    // Tests that circularly dependent objects can be used in schema and resolved correctly
+    // Test registering custom validation rules
     func testRegisteringCustomValidationRule() throws {
         struct TestResolver {
             var helloWorld: String { "Hellow World" }


### PR DESCRIPTION
This allows to specify custom validation rules that will be executed when a query is run. 
The logic already existed in GraphQL but wasn't exposed in Graphiti.

Use-Cases: E.g. disabling schema introspection in production (also done via validations in JS https://github.com/helfer/graphql-disable-introspection/blob/master/index.js).
We already had a short discussion about this over at the GraphQL repo: https://github.com/GraphQLSwift/GraphQL/issues/122

Discussions: 
- I experimented with multiple places where to expose the validation rules parameter. I added it to the normal schema execution function. But in the relatively new `API` world, I added it as an optional protocol requirement that can be implemented in the specify GraphQL API. **What do you think about this approach?**
- I used the types the GraphQL package uses for building custom validation rules instead of building new types only Graphiti uses to reduce overhead.

Feedback and change requests are welcome.