### PR TITLE
Makes PageInfo and Edge public to make custom connections easier

### DIFF
--- a/Sources/Graphiti/Connection/Connection.swift
+++ b/Sources/Graphiti/Connection/Connection.swift
@@ -3,8 +3,8 @@ import GraphQL
 import NIO
 
 public struct Connection<Node: Encodable>: Encodable {
-    let edges: [Edge<Node>]
-    let pageInfo: PageInfo
+    public let edges: [Edge<Node>]
+    public let pageInfo: PageInfo
 }
 
 @available(OSX 10.15, *)

--- a/Sources/Graphiti/Connection/Edge.swift
+++ b/Sources/Graphiti/Connection/Edge.swift
@@ -1,10 +1,10 @@
-protocol Edgeable {
+public protocol Edgeable {
     associatedtype Node: Encodable
     var node: Node { get }
     var cursor: String { get }
 }
 
-struct Edge<Node: Encodable>: Edgeable, Encodable {
-    let node: Node
-    let cursor: String
+public struct Edge<Node: Encodable>: Edgeable, Encodable {
+    public let node: Node
+    public let cursor: String
 }

--- a/Sources/Graphiti/Connection/Edge.swift
+++ b/Sources/Graphiti/Connection/Edge.swift
@@ -1,4 +1,4 @@
-public protocol Edgeable {
+protocol Edgeable {
     associatedtype Node: Encodable
     var node: Node { get }
     var cursor: String { get }

--- a/Sources/Graphiti/Connection/PageInfo.swift
+++ b/Sources/Graphiti/Connection/PageInfo.swift
@@ -1,4 +1,4 @@
-struct PageInfo: Codable {
+public struct PageInfo: Codable {
     let hasPreviousPage: Bool
     let hasNextPage: Bool
     let startCursor: String?

--- a/Sources/Graphiti/Connection/PageInfo.swift
+++ b/Sources/Graphiti/Connection/PageInfo.swift
@@ -1,6 +1,6 @@
 public struct PageInfo: Codable {
-    let hasPreviousPage: Bool
-    let hasNextPage: Bool
-    let startCursor: String?
-    let endCursor: String?
+    public let hasPreviousPage: Bool
+    public let hasNextPage: Bool
+    public let startCursor: String?
+    public let endCursor: String?
 }


### PR DESCRIPTION
This is a really small change, but it makes several Connection related types public including PageInfo, Edgeable, and Edge, so they can be used in custom connections.

My main concern is `PageInfo` because I want to create a custom connection, and right now `PageInfo` is internal and gets added to the schema automatically when using the default connections.  I figured `Edgeable` and `Edge` may be useful too.  It's possible much more of the Connection API could be made public as well.

Are there any downsides to doing this?