### PR TITLE
Add helper to API.execute

### DIFF
--- a/Sources/Graphiti/API/API.swift
+++ b/Sources/Graphiti/API/API.swift
@@ -28,6 +28,21 @@ public extension API {
         )
     }
 
+    func execute(
+        request: GraphQLRequest,
+        context: ContextType,
+        on eventLoopGroup: EventLoopGroup,
+        validationRules: [(ValidationContext) -> Visitor] = []
+    ) -> EventLoopFuture<GraphQLResult> {
+        return execute(request: request.query,
+                       context: context,
+                       on: eventLoopGroup,
+                       variables: request.variables,
+                       operationName: request.operationName,
+                       validationRules: validationRules
+        )
+    }
+
     func subscribe(
         request: String,
         context: ContextType,
@@ -43,6 +58,22 @@ public extension API {
             eventLoopGroup: eventLoopGroup,
             variables: variables,
             operationName: operationName,
+            validationRules: validationRules
+        )
+    }
+
+    func subscribe(
+        request: GraphQLRequest,
+        context: ContextType,
+        on eventLoopGroup: EventLoopGroup,
+        validationRules: [(ValidationContext) -> Visitor] = []
+    ) -> EventLoopFuture<SubscriptionResult> {
+        return subscribe(
+            request: request.query,
+            context: context,
+            on: eventLoopGroup,
+            variables: request.variables,
+            operationName: request.operationName,
             validationRules: validationRules
         )
     }
@@ -72,6 +103,23 @@ public extension API {
         }
 
         @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
+        func execute(
+            request: GraphQLRequest,
+            context: ContextType,
+            on eventLoopGroup: EventLoopGroup,
+            validationRules: [(ValidationContext) -> Visitor] = []
+        ) async throws -> GraphQLResult {
+            return try await execute(
+                request: request.query,
+                context: context,
+                on: eventLoopGroup,
+                variables: request.variables,
+                operationName: request.operationName,
+                validationRules: validationRules
+            )
+        }
+
+        @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
         func subscribe(
             request: String,
             context: ContextType,
@@ -89,6 +137,23 @@ public extension API {
                 operationName: operationName,
                 validationRules: validationRules
             ).get()
+        }
+
+        @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
+        func subscribe(
+            request: GraphQLRequest,
+            context: ContextType,
+            on eventLoopGroup: EventLoopGroup,
+            validationRules: [(ValidationContext) -> Visitor] = []
+        ) async throws -> SubscriptionResult {
+            return try await subscribe(
+                request: request.query,
+                context: context,
+                on: eventLoopGroup,
+                variables: request.variables,
+                operationName: request.operationName,
+                validationRules: validationRules
+            )
         }
     }
 

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
@@ -343,6 +343,40 @@ class HelloWorldTests: XCTestCase {
         wait(for: [expectation], timeout: 10)
     }
 
+    func testInputRequest() throws {
+        let mutation = """
+        mutation addUser($user: UserInput!) {
+            addUser(user: $user) {
+                id,
+                name
+            }
+        }
+        """
+        let variables: [String: Map] = ["user": ["id": "123", "name": "bob"]]
+
+        let request = GraphQLRequest(
+            query: mutation,
+            variables: variables
+        )
+
+        let expected = GraphQLResult(
+            data: ["addUser": ["id": "123", "name": "bob"]]
+        )
+
+        let expectation = XCTestExpectation()
+
+        api.execute(
+            request: request,
+            context: api.context,
+            on: group
+        ).whenSuccess { result in
+            XCTAssertEqual(result, expected)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 10)
+    }
+
     func testInputRecursive() throws {
         let mutation = """
         mutation addUser($user: UserInput!) {


### PR DESCRIPTION
Clients who decode the request body to `GraphQLRequest` can now use this helper to directly execute the request without having to decompose it into `query`, `variables` and `operationName`. 