### PR TITLE
chore: Adjusts format CI to use docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,14 @@ jobs:
     name: Format linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: swift-actions/setup-swift@v1
-      - name: GitHub Action for SwiftFormat
-        uses: CassiusPacheco/action-swiftformat@v0.1.0
-        with:
-          swiftformat-version: '0.49.11'
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Pull formatting docker image
+        run: docker pull ghcr.io/nicklockwood/swiftformat:latest
+      - name: Run format linting
+        run: docker run --rm -v ${{ github.workspace }}:/repo ghcr.io/nicklockwood/swiftformat:latest /repo --lint
 
   # Disabled until https://github.com/paulofaria/test-reporter is updated to Swift 5.4
   macos:

--- a/Sources/Graphiti/API/API.swift
+++ b/Sources/Graphiti/API/API.swift
@@ -34,12 +34,13 @@ public extension API {
         on eventLoopGroup: EventLoopGroup,
         validationRules: [(ValidationContext) -> Visitor] = []
     ) -> EventLoopFuture<GraphQLResult> {
-        return execute(request: request.query,
-                       context: context,
-                       on: eventLoopGroup,
-                       variables: request.variables,
-                       operationName: request.operationName,
-                       validationRules: validationRules
+        return execute(
+            request: request.query,
+            context: context,
+            on: eventLoopGroup,
+            variables: request.variables,
+            operationName: request.operationName,
+            validationRules: validationRules
         )
     }
 

--- a/Sources/Graphiti/Argument/Argument.swift
+++ b/Sources/Graphiti/Argument/Argument.swift
@@ -8,10 +8,10 @@ public class Argument<ArgumentsType: Decodable, ArgumentType>: ArgumentComponent
         typeProvider: TypeProvider,
         coders: Coders
     ) throws -> (String, GraphQLArgument) {
-        let argument = GraphQLArgument(
-            type: try typeProvider.getInputType(from: ArgumentType.self, field: name),
+        let argument = try GraphQLArgument(
+            type: typeProvider.getInputType(from: ArgumentType.self, field: name),
             description: description,
-            defaultValue: try defaultValue.map { try coders.encoder.encode($0) }
+            defaultValue: defaultValue.map { try coders.encoder.encode($0) }
         )
 
         return (name, argument)

--- a/Sources/Graphiti/Connection/Connection.swift
+++ b/Sources/Graphiti/Connection/Connection.swift
@@ -122,6 +122,7 @@ func connect<Node>(
     makeCursor: @escaping (Node) throws -> String
 ) throws -> Connection<Node> where Node: Encodable {
     let edges = try elements.map { element in
+        // swiftformat:disable:next hoistTry
         Edge<Node>(node: element, cursor: try makeCursor(element))
     }
 

--- a/Sources/Graphiti/Enum/Enum.swift
+++ b/Sources/Graphiti/Enum/Enum.swift
@@ -15,8 +15,8 @@ public final class Enum<
             name: name,
             description: description,
             values: values.reduce(into: [:]) { result, value in
-                result[value.value.rawValue] = GraphQLEnumValue(
-                    value: try MapEncoder().encode(value.value),
+                result[value.value.rawValue] = try GraphQLEnumValue(
+                    value: MapEncoder().encode(value.value),
                     description: value.description,
                     deprecationReason: value.deprecationReason
                 )

--- a/Sources/Graphiti/Federation/Any.swift
+++ b/Sources/Graphiti/Federation/Any.swift
@@ -3,9 +3,9 @@ import GraphQL
 let anyType = try! GraphQLScalarType(
     name: "_Any",
     description: "Scalar representing the JSON form of any type. A __typename field is required.",
-    serialize: { try map(from: $0) } ,
+    serialize: { try map(from: $0) },
     parseValue: { $0 },
     parseLiteral: { ast in
-        return ast.map
+        ast.map
     }
 )

--- a/Sources/Graphiti/Federation/Key/Key.swift
+++ b/Sources/Graphiti/Federation/Key/Key.swift
@@ -1,15 +1,19 @@
 import GraphQL
 import NIO
 
-public class Key<ObjectType, Resolver, Context, Arguments: Codable>: KeyComponent<ObjectType, Resolver, Context> {
+public class Key<ObjectType, Resolver, Context, Arguments: Codable>: KeyComponent<
+    ObjectType,
+    Resolver,
+    Context
+> {
     let arguments: [ArgumentComponent<Arguments>]
     let resolve: AsyncResolve<Resolver, Context, Arguments, ObjectType?>
-    
+
     override func mapMatchesArguments(_ map: Map, coders: Coders) -> Bool {
         let args = try? coders.decoder.decode(Arguments.self, from: map)
         return args != nil
     }
-    
+
     override func resolveMap(
         resolver: Resolver,
         context: Context,
@@ -18,10 +22,14 @@ public class Key<ObjectType, Resolver, Context, Arguments: Codable>: KeyComponen
         coders: Coders
     ) throws -> EventLoopFuture<Any?> {
         let arguments = try coders.decoder.decode(Arguments.self, from: map)
-        return try self.resolve(resolver)(context, arguments, eventLoopGroup).map { $0 as Any? }
+        return try resolve(resolver)(context, arguments, eventLoopGroup).map { $0 as Any? }
     }
-    
-    override func validate(againstFields fieldNames: [String], typeProvider: TypeProvider, coders: Coders) throws {
+
+    override func validate(
+        againstFields fieldNames: [String],
+        typeProvider: TypeProvider,
+        coders: Coders
+    ) throws {
         // Ensure that every argument is included in the provided field list
         for (name, _) in try arguments(typeProvider: typeProvider, coders: coders) {
             if !fieldNames.contains(name) {
@@ -46,7 +54,7 @@ public class Key<ObjectType, Resolver, Context, Arguments: Codable>: KeyComponen
         asyncResolve: @escaping AsyncResolve<Resolver, Context, Arguments, ObjectType?>
     ) {
         self.arguments = arguments
-        self.resolve = asyncResolve
+        resolve = asyncResolve
     }
 
     convenience init(

--- a/Sources/Graphiti/Federation/Key/KeyComponent.swift
+++ b/Sources/Graphiti/Federation/Key/KeyComponent.swift
@@ -2,21 +2,25 @@ import GraphQL
 import NIO
 
 public class KeyComponent<ObjectType, Resolver, Context> {
-    func mapMatchesArguments(_ map: Map, coders: Coders) -> Bool {
+    func mapMatchesArguments(_: Map, coders _: Coders) -> Bool {
         fatalError()
     }
-    
+
     func resolveMap(
-        resolver: Resolver,
-        context: Context,
-        map: Map,
-        eventLoopGroup: EventLoopGroup,
-        coders: Coders
+        resolver _: Resolver,
+        context _: Context,
+        map _: Map,
+        eventLoopGroup _: EventLoopGroup,
+        coders _: Coders
     ) throws -> EventLoopFuture<Any?> {
         fatalError()
     }
-    
-    func validate(againstFields fieldNames: [String], typeProvider: TypeProvider, coders: Coders) throws {
+
+    func validate(
+        againstFields _: [String],
+        typeProvider _: TypeProvider,
+        coders _: Coders
+    ) throws {
         fatalError()
     }
 }

--- a/Sources/Graphiti/Federation/Key/Type+Key.swift
+++ b/Sources/Graphiti/Federation/Key/Type+Key.swift
@@ -1,7 +1,6 @@
 import GraphQL
 
-extension Type {
-    
+public extension Type {
     @discardableResult
     /// Define and add the federated key to this type.
     ///
@@ -10,14 +9,14 @@ extension Type {
     ///   - function: The resolver function used to load this entity based on the key value.
     ///   - _:  The key value. The name of this argument must match a Type field.
     /// - Returns: Self for chaining.
-    public func key<Arguments: Codable>(
+    func key<Arguments: Codable>(
         at function: @escaping AsyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) -> Self {
         keys.append(Key(arguments: [argument()], asyncResolve: function))
         return self
     }
-    
+
     @discardableResult
     /// Define and add the federated key to this type.
     ///
@@ -26,15 +25,15 @@ extension Type {
     ///   - function: The resolver function used to load this entity based on the key value.
     ///   - _:  The key values. The names of these arguments must match Type fields.
     /// - Returns: Self for chaining.
-    public func key<Arguments: Codable>(
+    func key<Arguments: Codable>(
         at function: @escaping AsyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
-        -> [ArgumentComponent<Arguments>] = { [] }
+            -> [ArgumentComponent<Arguments>] = { [] }
     ) -> Self {
         keys.append(Key(arguments: arguments(), asyncResolve: function))
         return self
     }
-    
+
     @discardableResult
     /// Define and add the federated key to this type.
     ///
@@ -43,14 +42,14 @@ extension Type {
     ///   - function: The resolver function used to load this entity based on the key value.
     ///   - _:  The key value. The name of this argument must match a Type field.
     /// - Returns: Self for chaining.
-    public func key<Arguments: Codable>(
+    func key<Arguments: Codable>(
         at function: @escaping SimpleAsyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) -> Self {
         keys.append(Key(arguments: [argument()], simpleAsyncResolve: function))
         return self
     }
-    
+
     @discardableResult
     /// Define and add the federated key to this type.
     ///
@@ -59,15 +58,15 @@ extension Type {
     ///   - function: The resolver function used to load this entity based on the key value.
     ///   - _:  The key values. The names of these arguments must match Type fields.
     /// - Returns: Self for chaining.
-    public func key<Arguments: Codable>(
+    func key<Arguments: Codable>(
         at function: @escaping SimpleAsyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
-        -> [ArgumentComponent<Arguments>] = { [] }
+            -> [ArgumentComponent<Arguments>] = { [] }
     ) -> Self {
         keys.append(Key(arguments: arguments(), simpleAsyncResolve: function))
         return self
     }
-    
+
     @discardableResult
     /// Define and add the federated key to this type.
     ///
@@ -76,15 +75,15 @@ extension Type {
     ///   - function: The resolver function used to load this entity based on the key value.
     ///   - _:  The key value. The name of this argument must match a Type field.
     /// - Returns: Self for chaining.
-    public func key<Arguments: Codable>(
+    func key<Arguments: Codable>(
         at function: @escaping SyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
-        -> [ArgumentComponent<Arguments>] = { [] }
+            -> [ArgumentComponent<Arguments>] = { [] }
     ) -> Self {
         keys.append(Key(arguments: arguments(), syncResolve: function))
         return self
     }
-    
+
     @discardableResult
     /// Define and add the federated key to this type.
     ///
@@ -93,7 +92,7 @@ extension Type {
     ///   - function: The resolver function used to load this entity based on the key value.
     ///   - _:  The key values. The names of these arguments must match Type fields.
     /// - Returns: Self for chaining.
-    public func key<Arguments: Codable>(
+    func key<Arguments: Codable>(
         at function: @escaping SyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) -> Self {
@@ -101,43 +100,43 @@ extension Type {
         return self
     }
 }
-    
+
 #if compiler(>=5.5) && canImport(_Concurrency)
 
-public extension Type {
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
-    @discardableResult
-    /// Define and add the federated key to this type.
-    ///
-    /// For more information, see https://www.apollographql.com/docs/federation/entities
-    /// - Parameters:
-    ///   - function: The resolver function used to load this entity based on the key value.
-    ///   - _:  The key value. The name of this argument must match a Type field.
-    /// - Returns: Self for chaining.
-    func key<Arguments: Codable>(
-        at function: @escaping ConcurrentResolve<Resolver, Context, Arguments, ObjectType?>,
-        @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
-    ) -> Self {
-        keys.append(Key(arguments: [argument()], concurrentResolve: function))
-        return self
+    public extension Type {
+        @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
+        @discardableResult
+        /// Define and add the federated key to this type.
+        ///
+        /// For more information, see https://www.apollographql.com/docs/federation/entities
+        /// - Parameters:
+        ///   - function: The resolver function used to load this entity based on the key value.
+        ///   - _:  The key value. The name of this argument must match a Type field.
+        /// - Returns: Self for chaining.
+        func key<Arguments: Codable>(
+            at function: @escaping ConcurrentResolve<Resolver, Context, Arguments, ObjectType?>,
+            @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
+        ) -> Self {
+            keys.append(Key(arguments: [argument()], concurrentResolve: function))
+            return self
+        }
+
+        @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
+        @discardableResult
+        /// Define and add the federated key to this type.
+        ///
+        /// For more information, see https://www.apollographql.com/docs/federation/entities
+        /// - Parameters:
+        ///   - function: The resolver function used to load this entity based on the key value.
+        ///   - _:  The key values. The names of these arguments must match Type fields.
+        /// - Returns: Self for chaining.
+        func key<Arguments: Codable>(
+            at function: @escaping ConcurrentResolve<Resolver, Context, Arguments, ObjectType?>,
+            @ArgumentComponentBuilder<Arguments> _ arguments: () -> [ArgumentComponent<Arguments>]
+        ) -> Self {
+            keys.append(Key(arguments: arguments(), concurrentResolve: function))
+            return self
+        }
     }
-    
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
-    @discardableResult
-    /// Define and add the federated key to this type.
-    ///
-    /// For more information, see https://www.apollographql.com/docs/federation/entities
-    /// - Parameters:
-    ///   - function: The resolver function used to load this entity based on the key value.
-    ///   - _:  The key values. The names of these arguments must match Type fields.
-    /// - Returns: Self for chaining.
-    func key<Arguments: Codable>(
-        at function: @escaping ConcurrentResolve<Resolver, Context, Arguments, ObjectType?>,
-        @ArgumentComponentBuilder<Arguments> _ arguments: () -> [ArgumentComponent<Arguments>]
-    ) -> Self {
-        keys.append(Key(arguments: arguments(), concurrentResolve: function))
-        return self
-    }
-}
 
 #endif

--- a/Sources/Graphiti/Federation/Queries.swift
+++ b/Sources/Graphiti/Federation/Queries.swift
@@ -5,7 +5,7 @@ func serviceQuery(for sdl: String) -> GraphQLField {
     return GraphQLField(
         type: GraphQLNonNull(serviceType),
         description: "Return the SDL string for the subschema",
-        resolve: { source, args, context, eventLoopGroup, info in
+        resolve: { _, _, _, eventLoopGroup, _ in
             let result = Service(sdl: sdl)
             return eventLoopGroup.any().makeSucceededFuture(result)
         }
@@ -20,25 +20,30 @@ func entitiesQuery(
     return GraphQLField(
         type: GraphQLNonNull(GraphQLList(entityType)),
         description: "Return all entities matching the provided representations.",
-        args: ["representations": GraphQLArgument(type: GraphQLNonNull(GraphQLList(GraphQLNonNull(anyType))))],
+        args: [
+            "representations": GraphQLArgument(type: GraphQLNonNull(GraphQLList(GraphQLNonNull(anyType)))),
+        ],
         resolve: { source, args, context, eventLoopGroup, info in
             let arguments = try coders.decoder.decode(EntityArguments.self, from: args)
-            let futures: [EventLoopFuture<Any?>] = try arguments.representations.map { (representationMap: Map) in
-                let representation = try coders.decoder.decode(
-                    EntityRepresentation.self,
-                    from: representationMap
-                )
-                guard let resolve = federatedResolvers[representation.__typename] else {
-                    throw GraphQLError(message: "Federated type not found: \(representation.__typename)")
+            let futures: [EventLoopFuture<Any?>] = try arguments.representations
+                .map { (representationMap: Map) in
+                    let representation = try coders.decoder.decode(
+                        EntityRepresentation.self,
+                        from: representationMap
+                    )
+                    guard let resolve = federatedResolvers[representation.__typename] else {
+                        throw GraphQLError(
+                            message: "Federated type not found: \(representation.__typename)"
+                        )
+                    }
+                    return try resolve(
+                        source,
+                        representationMap,
+                        context,
+                        eventLoopGroup,
+                        info
+                    )
                 }
-                return try resolve(
-                    source,
-                    representationMap,
-                    context,
-                    eventLoopGroup,
-                    info
-                )
-            }
 
             return futures.flatten(on: eventLoopGroup)
                 .map { $0 as Any? }

--- a/Sources/Graphiti/Federation/Service.swift
+++ b/Sources/Graphiti/Federation/Service.swift
@@ -8,6 +8,6 @@ let serviceType = try! GraphQLObjectType(
     name: "_Service",
     description: "Federation service object",
     fields: [
-        "sdl": GraphQLField(type: GraphQLString)
+        "sdl": GraphQLField(type: GraphQLString),
     ]
 )

--- a/Sources/Graphiti/Field/Field/Field.swift
+++ b/Sources/Graphiti/Field/Field/Field.swift
@@ -13,11 +13,11 @@ public class Field<ObjectType, Context, FieldType, Arguments: Decodable>: FieldC
         typeProvider: TypeProvider,
         coders: Coders
     ) throws -> (String, GraphQLField) {
-        let field = GraphQLField(
-            type: try typeProvider.getOutputType(from: FieldType.self, field: name),
+        let field = try GraphQLField(
+            type: typeProvider.getOutputType(from: FieldType.self, field: name),
             description: description,
             deprecationReason: deprecationReason,
-            args: try arguments(typeProvider: typeProvider, coders: coders),
+            args: arguments(typeProvider: typeProvider, coders: coders),
             resolve: { source, arguments, context, eventLoopGroup, _ in
                 guard let s = source as? ObjectType else {
                     throw GraphQLError(

--- a/Sources/Graphiti/InputField/InputField.swift
+++ b/Sources/Graphiti/InputField/InputField.swift
@@ -12,9 +12,9 @@ public class InputField<
     var defaultValue: AnyEncodable?
 
     override func field(typeProvider: TypeProvider) throws -> (String, InputObjectField) {
-        let field = InputObjectField(
-            type: try typeProvider.getInputType(from: FieldType.self, field: name),
-            defaultValue: try defaultValue.map {
+        let field = try InputObjectField(
+            type: typeProvider.getInputType(from: FieldType.self, field: name),
+            defaultValue: defaultValue.map {
                 try MapEncoder().encode($0)
             },
             description: description

--- a/Sources/Graphiti/Query/Query.swift
+++ b/Sources/Graphiti/Query/Query.swift
@@ -9,20 +9,20 @@ public final class Query<Resolver, Context>: Component<Resolver, Context> {
 
     override func update(typeProvider: SchemaTypeProvider, coders: Coders) throws {
         var queryFields = try fields(typeProvider: typeProvider, coders: coders)
-        
+
         // Add federated types and queries if they exist
         if !typeProvider.federatedTypes.isEmpty {
             let federatedTypes = typeProvider.federatedTypes
             guard let sdl = typeProvider.federatedSDL else {
                 throw GraphQLError(message: "If federated types are included, SDL must be provided")
             }
-            
+
             // Add subgraph types to provider (_Service, _Any, _Entity)
             let entity = entityType(federatedTypes)
             typeProvider.types.append(serviceType)
             typeProvider.types.append(anyType)
             typeProvider.types.append(entity)
-            
+
             // Add subgraph queries (_entities, _service)
             queryFields["_entities"] = entitiesQuery(
                 for: typeProvider.federatedResolvers,
@@ -31,7 +31,7 @@ public final class Query<Resolver, Context>: Component<Resolver, Context> {
             )
             queryFields["_service"] = serviceQuery(for: sdl)
         }
-        
+
         typeProvider.query = try GraphQLObjectType(
             name: name,
             description: description,

--- a/Sources/Graphiti/Schema/SchemaTypeProvider.swift
+++ b/Sources/Graphiti/Schema/SchemaTypeProvider.swift
@@ -14,7 +14,7 @@ final class SchemaTypeProvider: TypeProvider {
         AnyType(String.self): GraphQLString,
         AnyType(Bool.self): GraphQLBoolean,
     ]
-    
+
     var federatedTypes: [GraphQLObjectType] = []
     var federatedResolvers: [String: GraphQLFieldResolve] = [:]
     var federatedSDL: String? = nil

--- a/Sources/Graphiti/SchemaBuilders/SchemaBuilder.swift
+++ b/Sources/Graphiti/SchemaBuilders/SchemaBuilder.swift
@@ -35,7 +35,7 @@ public final class SchemaBuilder<Resolver, Context> {
         coders = newCoders
         return self
     }
-    
+
     @discardableResult
     /// Allows for setting SDL for federated subgraphs.
     /// - Parameter newSDL: The new SDL to use

--- a/Sources/Graphiti/Subscription/SubscribeField.swift
+++ b/Sources/Graphiti/Subscription/SubscribeField.swift
@@ -19,11 +19,11 @@ public class SubscriptionField<
         typeProvider: TypeProvider,
         coders: Coders
     ) throws -> (String, GraphQLField) {
-        let field = GraphQLField(
-            type: try typeProvider.getOutputType(from: FieldType.self, field: name),
+        let field = try GraphQLField(
+            type: typeProvider.getOutputType(from: FieldType.self, field: name),
             description: description,
             deprecationReason: deprecationReason,
-            args: try arguments(typeProvider: typeProvider, coders: coders),
+            args: arguments(typeProvider: typeProvider, coders: coders),
             resolve: { source, arguments, context, eventLoopGroup, _ in
                 guard let _source = source as? SourceEventType else {
                     throw GraphQLError(

--- a/Sources/Graphiti/Type/Type.swift
+++ b/Sources/Graphiti/Type/Type.swift
@@ -11,7 +11,7 @@ public final class Type<Resolver, Context, ObjectType: Encodable>: TypeComponent
     let isTypeOf: GraphQLIsTypeOf = { source, _, _ in
         source is ObjectType
     }
-    
+
     override func update(typeProvider: SchemaTypeProvider, coders: Coders) throws {
         let fieldDefs = try fields(typeProvider: typeProvider, coders: coders)
         let objectType = try GraphQLObjectType(
@@ -23,9 +23,9 @@ public final class Type<Resolver, Context, ObjectType: Encodable>: TypeComponent
             },
             isTypeOf: isTypeOf
         )
-        
+
         try typeProvider.add(type: ObjectType.self, as: objectType)
-        
+
         // If federation keys are included, validate and create resolver closure
         if !keys.isEmpty {
             let fieldNames = Array(fieldDefs.keys)
@@ -36,8 +36,8 @@ public final class Type<Resolver, Context, ObjectType: Encodable>: TypeComponent
                     coders: coders
                 )
             }
-            
-            let resolve: GraphQLFieldResolve = { source, args, context, eventLoopGroup, info in
+
+            let resolve: GraphQLFieldResolve = { source, args, context, eventLoopGroup, _ in
                 guard let s = source as? Resolver else {
                     throw GraphQLError(
                         message: "Expected source type \(ObjectType.self) but got \(type(of: source))"
@@ -49,7 +49,7 @@ public final class Type<Resolver, Context, ObjectType: Encodable>: TypeComponent
                         message: "Expected context type \(Context.self) but got \(type(of: context))"
                     )
                 }
-                
+
                 let keyMatch = self.keys.first { key in
                     key.mapMatchesArguments(args, coders: coders)
                 }
@@ -58,7 +58,7 @@ public final class Type<Resolver, Context, ObjectType: Encodable>: TypeComponent
                         message: "No matching key was found for representation \(args)."
                     )
                 }
-                
+
                 return try key.resolveMap(
                     resolver: s,
                     context: c,
@@ -67,7 +67,7 @@ public final class Type<Resolver, Context, ObjectType: Encodable>: TypeComponent
                     coders: coders
                 )
             }
-            
+
             typeProvider.federatedTypes.append(objectType)
             typeProvider.federatedResolvers[name] = resolve
         }

--- a/Sources/Graphiti/Validation/NoIntrospectionRule.swift
+++ b/Sources/Graphiti/Validation/NoIntrospectionRule.swift
@@ -3,7 +3,10 @@ import GraphQL
 public func NoIntrospectionRule(context: ValidationContext) -> Visitor {
     return Visitor(enter: { node, _, _, _, _ in
         if let field = node as? GraphQL.Field, ["__schema", "__type"].contains(field.name.value) {
-            context.report(error: .init(message: "GraphQL introspection is not allowed, but the query contained __schema or __type", nodes: [node]))
+            context.report(error: .init(
+                message: "GraphQL introspection is not allowed, but the query contained __schema or __type",
+                nodes: [node]
+            ))
         }
         return .continue
     })

--- a/Tests/GraphitiTests/FederationTests/FederationTests.swift
+++ b/Tests/GraphitiTests/FederationTests/FederationTests.swift
@@ -13,8 +13,8 @@ final class FederationTests: XCTestCase {
             .use(partials: [ProductSchema()])
             .setFederatedSDL(to: loadSDL())
             .build()
-        self.group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        self.api = try ProductAPI(resolver: ProductResolver(sdl: loadSDL()), schema: schema)
+        group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        api = try ProductAPI(resolver: ProductResolver(sdl: loadSDL()), schema: schema)
     }
 
     override func tearDownWithError() throws {
@@ -22,209 +22,240 @@ final class FederationTests: XCTestCase {
         group = nil
         api = nil
     }
-    
+
     // Test Queries from https://github.com/apollographql/apollo-federation-subgraph-compatibility/blob/main/COMPATIBILITY.md
 
     func testServiceQuery() throws {
         try XCTAssertEqual(execute(request: query("service")), GraphQLResult(data: [
             "_service": [
-                "sdl": Map(stringLiteral: loadSDL())
-            ]
+                "sdl": Map(stringLiteral: loadSDL()),
+            ],
         ]))
     }
 
     func testEntityKey() throws {
-        let representations: [String : Map] = [
-            "representations" : [
-                [ "__typename": "User", "email": "support@apollographql.com" ]
-            ]
+        let representations: [String: Map] = [
+            "representations": [
+                ["__typename": "User", "email": "support@apollographql.com"],
+            ],
         ]
 
-        try XCTAssertEqual(execute(request: query("entities"), variables: representations), GraphQLResult(data: [
-            "_entities": [
-                [
-                    "email": "support@apollographql.com",
-                    "name": "Jane Smith",
-                    "totalProductsCreated": 1337,
-                    "yearsOfEmployment": 10,
-                    "averageProductsCreatedPerYear": 133,
-                ]
-            ]
-        ]))
-    }
-
-    func testEntityMultipleKey() throws {
-        let representations: [String : Map] = [
-            "representations" : [
-                [ "__typename": "DeprecatedProduct", "sku": "apollo-federation-v1", "package": "@apollo/federation-v1" ]
-            ]
-        ]
-
-        try XCTAssertEqual(execute(request: query("entities"), variables: representations), GraphQLResult(data: [
-            "_entities": [
-                [
-                    "sku": "apollo-federation-v1",
-                    "package": "@apollo/federation-v1",
-                    "reason": "Migrate to Federation V2",
-                    "createdBy": [
+        try XCTAssertEqual(
+            execute(request: query("entities"), variables: representations),
+            GraphQLResult(data: [
+                "_entities": [
+                    [
                         "email": "support@apollographql.com",
                         "name": "Jane Smith",
                         "totalProductsCreated": 1337,
                         "yearsOfEmployment": 10,
                         "averageProductsCreatedPerYear": 133,
-                    ]
-                ]
-            ]
-        ]))
+                    ],
+                ],
+            ])
+        )
+    }
+
+    func testEntityMultipleKey() throws {
+        let representations: [String: Map] = [
+            "representations": [
+                [
+                    "__typename": "DeprecatedProduct",
+                    "sku": "apollo-federation-v1",
+                    "package": "@apollo/federation-v1",
+                ],
+            ],
+        ]
+
+        try XCTAssertEqual(
+            execute(request: query("entities"), variables: representations),
+            GraphQLResult(data: [
+                "_entities": [
+                    [
+                        "sku": "apollo-federation-v1",
+                        "package": "@apollo/federation-v1",
+                        "reason": "Migrate to Federation V2",
+                        "createdBy": [
+                            "email": "support@apollographql.com",
+                            "name": "Jane Smith",
+                            "totalProductsCreated": 1337,
+                            "yearsOfEmployment": 10,
+                            "averageProductsCreatedPerYear": 133,
+                        ],
+                    ],
+                ],
+            ])
+        )
     }
 
     func testEntityCompositeKey() throws {
-        let representations: [String : Map] = [
-            "representations" : [
-                [ "__typename": "ProductResearch", "study": [ "caseNumber": "1234" ] ]
-            ]
+        let representations: [String: Map] = [
+            "representations": [
+                ["__typename": "ProductResearch", "study": ["caseNumber": "1234"]],
+            ],
         ]
 
-        try XCTAssertEqual(execute(request: query("entities"), variables: representations), GraphQLResult(data: [
-            "_entities": [
-                [
-                    "study": [
-                        "caseNumber": "1234",
-                        "description": "Federation Study"
+        try XCTAssertEqual(
+            execute(request: query("entities"), variables: representations),
+            GraphQLResult(data: [
+                "_entities": [
+                    [
+                        "study": [
+                            "caseNumber": "1234",
+                            "description": "Federation Study",
+                        ],
+                        "outcome": nil,
                     ],
-                    "outcome": nil
-                ]
-            ]
-        ]))
+                ],
+            ])
+        )
     }
 
     func testEntityMultipleKeys() throws {
-        let representations: [String : Map] = [
-            "representations" : [
-                [ "__typename": "Product", "id": "apollo-federation" ],
-                [ "__typename": "Product", "sku": "federation", "package": "@apollo/federation" ],
-                [ "__typename": "Product", "sku": "studio", "variation": [ "id": "platform" ] ],
-            ]
+        let representations: [String: Map] = [
+            "representations": [
+                ["__typename": "Product", "id": "apollo-federation"],
+                ["__typename": "Product", "sku": "federation", "package": "@apollo/federation"],
+                ["__typename": "Product", "sku": "studio", "variation": ["id": "platform"]],
+            ],
         ]
 
-        try XCTAssertEqual(execute(request: query("entities"), variables: representations), GraphQLResult(data: [
-            "_entities": [
-                [
-                    "id": "apollo-federation",
-                    "sku": "federation",
-                    "package": "@apollo/federation",
-                    "variation": [
-                        "id": "OSS"
+        try XCTAssertEqual(
+            execute(request: query("entities"), variables: representations),
+            GraphQLResult(data: [
+                "_entities": [
+                    [
+                        "id": "apollo-federation",
+                        "sku": "federation",
+                        "package": "@apollo/federation",
+                        "variation": [
+                            "id": "OSS",
+                        ],
+                        "dimensions": [
+                            "size": "small",
+                            "unit": "kg",
+                            "weight": 1,
+                        ],
+                        "createdBy": [
+                            "email": "support@apollographql.com",
+                            "name": "Jane Smith",
+                            "totalProductsCreated": 1337,
+                            "yearsOfEmployment": 10,
+                            "averageProductsCreatedPerYear": 133,
+                        ],
+                        "notes": nil,
+                        "research": [
+                            [
+                                "outcome": nil,
+                                "study": [
+                                    "caseNumber": "1234",
+                                    "description": "Federation Study",
+                                ],
+                            ],
+                        ],
                     ],
-                    "dimensions": [
-                        "size": "small",
-                        "unit": "kg",
-                        "weight": 1
+                    [
+                        "id": "apollo-federation",
+                        "sku": "federation",
+                        "package": "@apollo/federation",
+                        "variation": [
+                            "id": "OSS",
+                        ],
+                        "dimensions": [
+                            "size": "small",
+                            "unit": "kg",
+                            "weight": 1,
+                        ],
+                        "createdBy": [
+                            "email": "support@apollographql.com",
+                            "name": "Jane Smith",
+                            "totalProductsCreated": 1337,
+                            "yearsOfEmployment": 10,
+                            "averageProductsCreatedPerYear": 133,
+                        ],
+                        "notes": nil,
+                        "research": [
+                            [
+                                "outcome": nil,
+                                "study": [
+                                    "caseNumber": "1234",
+                                    "description": "Federation Study",
+                                ],
+                            ],
+                        ],
                     ],
-                    "createdBy": [
-                        "email": "support@apollographql.com",
-                        "name": "Jane Smith",
-                        "totalProductsCreated": 1337,
-                        "yearsOfEmployment":10,
-                        "averageProductsCreatedPerYear":133,
+                    [
+                        "id": "apollo-studio",
+                        "sku": "studio",
+                        "package": "",
+                        "variation": [
+                            "id": "platform",
+                        ],
+                        "dimensions": [
+                            "size": "small",
+                            "unit": "kg",
+                            "weight": 1,
+                        ],
+                        "createdBy": [
+                            "email": "support@apollographql.com",
+                            "name": "Jane Smith",
+                            "totalProductsCreated": 1337,
+                            "yearsOfEmployment": 10,
+                            "averageProductsCreatedPerYear": 133,
+                        ],
+                        "notes": nil,
+                        "research": [
+                            [
+                                "outcome": nil,
+                                "study": [
+                                    "caseNumber": "1235",
+                                    "description": "Studio Study",
+                                ],
+                            ],
+                        ],
                     ],
-                    "notes": nil,
-                    "research": [
-                        [
-                            "outcome": nil,
-                            "study": [
-                                "caseNumber": "1234",
-                                "description": "Federation Study"
-                            ]
-                        ]
-                    ]
                 ],
-                [
-                    "id": "apollo-federation",
-                    "sku": "federation",
-                    "package": "@apollo/federation",
-                    "variation": [
-                        "id": "OSS"
-                    ],
-                    "dimensions": [
-                        "size": "small",
-                        "unit": "kg",
-                        "weight": 1
-                    ],
-                    "createdBy": [
-                        "email": "support@apollographql.com",
-                        "name": "Jane Smith",
-                        "totalProductsCreated": 1337,
-                        "yearsOfEmployment":10,
-                        "averageProductsCreatedPerYear":133,
-                    ],
-                    "notes": nil,
-                    "research": [
-                        [
-                            "outcome": nil,
-                            "study": [
-                                "caseNumber": "1234",
-                                "description": "Federation Study"
-                            ]
-                        ]
-                    ]
-                ],
-                [
-                    "id": "apollo-studio",
-                    "sku": "studio",
-                    "package": "",
-                    "variation": [
-                        "id": "platform"
-                    ],
-                    "dimensions": [
-                        "size": "small",
-                        "unit": "kg",
-                        "weight": 1
-                    ],
-                    "createdBy": [
-                        "email": "support@apollographql.com",
-                        "name": "Jane Smith",
-                        "totalProductsCreated": 1337,
-                        "yearsOfEmployment":10,
-                        "averageProductsCreatedPerYear":133,
-                    ],
-                    "notes": nil,
-                    "research": [
-                        [
-                            "outcome": nil,
-                            "study": [
-                                "caseNumber": "1235",
-                                "description": "Studio Study"
-                            ]
-                        ]
-                    ]
-                ]
-            ]
-        ]))
+            ])
+        )
     }
 }
 
 // MARK: - Helpers
+
 extension FederationTests {
     enum FederationTestsError: Error {
         case couldNotLoadFile
     }
 
     func loadSDL() throws -> String {
-        guard let url = Bundle.module.url(forResource: "product", withExtension: "graphqls", subdirectory: "GraphQL") else {
+        guard
+            let url = Bundle.module.url(
+                forResource: "product",
+                withExtension: "graphqls",
+                subdirectory: "GraphQL"
+            )
+        else {
             throw FederationTestsError.couldNotLoadFile
         }
         return try String(contentsOf: url)
     }
 
     func query(_ name: String) throws -> String {
-        guard let url = Bundle.module.url(forResource: name, withExtension: "graphql", subdirectory: "GraphQL") else {
+        guard
+            let url = Bundle.module.url(
+                forResource: name,
+                withExtension: "graphql",
+                subdirectory: "GraphQL"
+            )
+        else {
             throw FederationTestsError.couldNotLoadFile
         }
         return try String(contentsOf: url)
     }
 
     func execute(request: String, variables: [String: Map] = [:]) throws -> GraphQLResult {
-        try api.execute(request: request, context: ProductContext(), on: group, variables: variables).wait()
+        try api
+            .execute(request: request, context: ProductContext(), on: group, variables: variables)
+            .wait()
     }
 }

--- a/Tests/GraphitiTests/ProductAPI/ProductContext.swift
+++ b/Tests/GraphitiTests/ProductAPI/ProductContext.swift
@@ -6,7 +6,7 @@ struct ProductContext {
             size: "small",
             weight: 1,
             unit: "kg"
-        )
+        ),
     ]
 
     static let users = [
@@ -40,7 +40,8 @@ struct ProductContext {
                 caseNumber: "1235",
                 description: "Studio Study"
             ),
-            outcome: nil),
+            outcome: nil
+        ),
     ]
 
     static let products = [

--- a/Tests/GraphitiTests/ProductAPI/ProductResolver.swift
+++ b/Tests/GraphitiTests/ProductAPI/ProductResolver.swift
@@ -1,29 +1,39 @@
 import Foundation
-import GraphQL
 import Graphiti
+import GraphQL
 import NIO
 
 struct ProductResolver {
     var sdl: String
-    
+
     func getProduct1(context: ProductContext, arguments: Product.EntityKey1) -> Product? {
         type(of: context).products.first { $0.id == arguments.id }
     }
 
     func getProduct2(context: ProductContext, arguments: Product.EntityKey2) -> Product? {
-        type(of: context).products.first { $0.sku == arguments.sku && $0.package == arguments.package }
+        type(of: context).products
+            .first { $0.sku == arguments.sku && $0.package == arguments.package }
     }
 
     func getProduct3(context: ProductContext, arguments: Product.EntityKey3) -> Product? {
-        type(of: context).products.first { $0.sku == arguments.sku && $0.variation?.id == arguments.variation.id }
+        type(of: context).products
+            .first { $0.sku == arguments.sku && $0.variation?.id == arguments.variation.id }
     }
 
-    func getDeprecatedProduct(context: ProductContext, arguments: DeprecatedProduct.EntityKey) -> DeprecatedProduct? {
-        type(of: context).deprecatedProducts.first { $0.sku == arguments.sku && $0.package == arguments.package }
+    func getDeprecatedProduct(
+        context: ProductContext,
+        arguments: DeprecatedProduct.EntityKey
+    ) -> DeprecatedProduct? {
+        type(of: context).deprecatedProducts
+            .first { $0.sku == arguments.sku && $0.package == arguments.package }
     }
 
-    func getProductResearch(context: ProductContext, arguments: ProductResearch.EntityKey) -> ProductResearch? {
-        type(of: context).productsResearch.first { $0.study.caseNumber == arguments.study.caseNumber }
+    func getProductResearch(
+        context: ProductContext,
+        arguments: ProductResearch.EntityKey
+    ) -> ProductResearch? {
+        type(of: context).productsResearch
+            .first { $0.study.caseNumber == arguments.study.caseNumber }
     }
 
     func getUser(context: ProductContext, arguments: ProductUser.EntityKey) -> ProductUser? {

--- a/Tests/GraphitiTests/ProductAPI/ProductSchema.swift
+++ b/Tests/GraphitiTests/ProductAPI/ProductSchema.swift
@@ -7,7 +7,7 @@ final class ProductSchema: PartialSchema<ProductResolver, ProductContext> {
     @TypeDefinitions
     override var types: Types {
         Scalar(Float.self)
-        
+
         Type(Product.self) {
             Field("id", at: \.id)
             Field("sku", at: \.sku)
@@ -26,7 +26,7 @@ final class ProductSchema: PartialSchema<ProductResolver, ProductContext> {
             Argument("sku", at: \.sku)
             Argument("variation", at: \.variation)
         }
-        
+
         Type(DeprecatedProduct.self) {
             Field("sku", at: \.sku)
             Field("package", at: \.package)
@@ -36,29 +36,29 @@ final class ProductSchema: PartialSchema<ProductResolver, ProductContext> {
             Argument("sku", at: \.sku)
             Argument("package", at: \.package)
         }
-        
+
         Type(ProductVariation.self) {
             Field("id", at: \.id)
         }
-        
+
         Type(ProductResearch.self) {
             Field("study", at: \.study)
             Field("outcome", at: \.outcome)
         }.key(at: ProductResolver.getProductResearch) {
             Argument("study", at: \.study)
         }
-        
+
         Type(CaseStudy.self) {
             Field("caseNumber", at: \.caseNumber)
             Field("description", at: \.description)
         }
-        
+
         Type(ProductDimension.self) {
             Field("size", at: \.size)
             Field("weight", at: \.weight)
             Field("unit", at: \.unit)
         }
-        
+
         Type(ProductUser.self, as: "User") {
             Field("email", at: \.email)
             Field("name", at: \.name)

--- a/Tests/GraphitiTests/ValidationRulesTests.swift
+++ b/Tests/GraphitiTests/ValidationRulesTests.swift
@@ -10,7 +10,7 @@ class ValidationRulesTests: XCTestCase {
         struct TestResolver {
             var helloWorld: String { "Hellow World" }
         }
-        
+
         let testSchema = try Schema<TestResolver, NoContext> {
             Query {
                 Field("helloWorld", at: \.helloWorld)
@@ -39,7 +39,10 @@ class ValidationRulesTests: XCTestCase {
                 validationRules: [NoIntrospectionRule]
             ).wait(),
             GraphQLResult(errors: [
-                .init(message: "GraphQL introspection is not allowed, but the query contained __schema or __type", locations: [.init(line: 2, column: 3)])
+                .init(
+                    message: "GraphQL introspection is not allowed, but the query contained __schema or __type",
+                    locations: [.init(line: 2, column: 3)]
+                ),
             ])
         )
     }


### PR DESCRIPTION
This was done because the [swiftformat action](https://github.com/CassiusPacheco/action-swiftformat/blob/main/action.yml) was unable to run in `lint` mode, so contributors didn't know what formatting must be fixed.