### PR TITLE
Made inits public for NoArguments and PageInfo

### DIFF
--- a/Sources/Graphiti/Argument/NoArguments.swift
+++ b/Sources/Graphiti/Argument/NoArguments.swift
@@ -1,3 +1,3 @@
 public struct NoArguments: Decodable {
-    init() {}
+    public init() {}
 }

--- a/Sources/Graphiti/Connection/PageInfo.swift
+++ b/Sources/Graphiti/Connection/PageInfo.swift
@@ -3,4 +3,11 @@ public struct PageInfo: Codable {
     public let hasNextPage: Bool
     public let startCursor: String?
     public let endCursor: String?
+    
+    public init(hasPreviousPage: Bool, hasNextPage: Bool, startCursor: String? = nil, endCursor: String? = nil) {
+        self.hasPreviousPage = hasPreviousPage
+        self.hasNextPage = hasNextPage
+        self.startCursor = startCursor
+        self.endCursor = endCursor
+    }
 }

--- a/Sources/Graphiti/Connection/PageInfo.swift
+++ b/Sources/Graphiti/Connection/PageInfo.swift
@@ -3,8 +3,13 @@ public struct PageInfo: Codable {
     public let hasNextPage: Bool
     public let startCursor: String?
     public let endCursor: String?
-    
-    public init(hasPreviousPage: Bool, hasNextPage: Bool, startCursor: String? = nil, endCursor: String? = nil) {
+
+    public init(
+        hasPreviousPage: Bool,
+        hasNextPage: Bool,
+        startCursor: String? = nil,
+        endCursor: String? = nil
+    ) {
         self.hasPreviousPage = hasPreviousPage
         self.hasNextPage = hasNextPage
         self.startCursor = startCursor

--- a/Tests/GraphitiTests/ConnectionTests.swift
+++ b/Tests/GraphitiTests/ConnectionTests.swift
@@ -22,25 +22,23 @@ class ConnectionTests: XCTestCase {
         }
     }
 
-    let schema = {
-        try! Schema<ConnectionTypeResolver, NoContext> {
-            Type(Comment.self) {
-                Field("id", at: \.id)
-                Field("message", at: \.message)
-            }
+    let schema = try! Schema<ConnectionTypeResolver, NoContext> {
+        Type(Comment.self) {
+            Field("id", at: \.id)
+            Field("message", at: \.message)
+        }
 
-            ConnectionType(Comment.self)
+        ConnectionType(Comment.self)
 
-            Query {
-                Field("comments", at: ConnectionTypeResolver.comments) {
-                    Argument("first", at: \.first)
-                    Argument("last", at: \.last)
-                    Argument("after", at: \.after)
-                    Argument("before", at: \.before)
-                }
+        Query {
+            Field("comments", at: ConnectionTypeResolver.comments) {
+                Argument("first", at: \.first)
+                Argument("last", at: \.last)
+                Argument("after", at: \.after)
+                Argument("before", at: \.before)
             }
         }
-    }()
+    }
 
     let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 


### PR DESCRIPTION
Addresses #124 to make inits public for both PageInfo and NoArguments.  This should help with custom connections and enable people to call resolvers with no arguments directly.