### PR TITLE
Exports code coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,21 +32,10 @@ jobs:
         xcode-version: latest
     - uses: actions/checkout@v3
     - name: Build and test
-      run: swift test --parallel --enable-test-discovery --enable-code-coverage
-    - name: Get test coverage html
-      run: llvm-cov show \
-        .build/x86_64-apple-macosx/debug/GraphitiPackageTests.xctest/Contents/MacOS/GraphitiPackageTests \
-        --instr-profile .build/x86_64-apple-macosx/debug/codecov/default.profdata \
-        --format html \
-        --output-dir=.test-coverage
-    - name: Upload test coverage html
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-coverage-report
-        path: .test-coverage
+      run: swift test --parallel --enable-test-discovery
 
-  # ubuntu-latest is ubuntu-22.04 currently. Swift versions older than 5.7 don't have builds for 22.04. https://www.swift.org/download/ 
-  ubuntu-old:
+  # Swift versions older than 5.7 don't have builds for ubuntu 22.04. https://www.swift.org/download/ 
+  ubuntu-20_04:
     name: Build ${{ matrix.swift }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -61,12 +50,12 @@ jobs:
     - name: Test
       run: swift test --parallel
 
-  ubuntu-latest:
+  ubuntu-22_04:
     name: Build ${{ matrix.swift }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest] 
+        os: [ubuntu-22.04] 
         swift: ["5.7"]
     steps:
     - uses: swift-actions/setup-swift@v1
@@ -75,3 +64,24 @@ jobs:
     - uses: actions/checkout@v3
     - name: Test
       run: swift test --parallel
+
+  ubuntu-latest:
+    name: Build latest on ubuntu
+    runs-on: ubuntu-latest
+    steps:
+    - uses: swift-actions/setup-swift@v1
+    - uses: actions/checkout@v3
+    - name: Test
+      run: swift test --parallel --enable-code-coverage
+    - name: Get test coverage html
+      run: |
+        llvm-cov show \
+          $(swift build --show-bin-path)/GraphitiPackageTests.xctest \
+          --instr-profile $(swift build --show-bin-path)/codecov/default.profdata \
+          --format html \
+          --output-dir=.test-coverage
+    - name: Upload test coverage html
+      uses: actions/upload-artifact@v3
+      with:
+        name: test-coverage-report
+        path: .test-coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         run: docker run --rm -v ${{ github.workspace }}:/repo ghcr.io/nicklockwood/swiftformat:latest /repo --lint
 
   macos:
-    name: Build and test on macOS
+    name: Test on macOS
     runs-on: macOS-latest
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
@@ -34,39 +34,8 @@ jobs:
     - name: Build and test
       run: swift test --parallel --enable-test-discovery
 
-  # Swift versions older than 5.7 don't have builds for ubuntu 22.04. https://www.swift.org/download/ 
-  ubuntu-20_04:
-    name: Build ${{ matrix.swift }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04] 
-        swift: ["5.4", "5.5", "5.6"]
-    steps:
-    - uses: swift-actions/setup-swift@v1
-      with:
-        swift-version: ${{ matrix.swift }}
-    - uses: actions/checkout@v3
-    - name: Test
-      run: swift test --parallel
-
-  ubuntu-22_04:
-    name: Build ${{ matrix.swift }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-22.04] 
-        swift: ["5.7"]
-    steps:
-    - uses: swift-actions/setup-swift@v1
-      with:
-        swift-version: ${{ matrix.swift }}
-    - uses: actions/checkout@v3
-    - name: Test
-      run: swift test --parallel
-
-  ubuntu-latest:
-    name: Build latest on ubuntu
+  linux:
+    name: Test on Linux
     runs-on: ubuntu-latest
     steps:
     - uses: swift-actions/setup-swift@v1
@@ -78,6 +47,7 @@ jobs:
         llvm-cov show \
           $(swift build --show-bin-path)/GraphitiPackageTests.xctest \
           --instr-profile $(swift build --show-bin-path)/codecov/default.profdata \
+          --ignore-filename-regex="\.build|Tests" \
           --format html \
           --output-dir=.test-coverage
     - name: Upload test coverage html
@@ -85,3 +55,32 @@ jobs:
       with:
         name: test-coverage-report
         path: .test-coverage
+
+  backcompat-ubuntu-22_04:
+    name: Test Swift ${{ matrix.swift }} on Ubuntu 22.04
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        swift: ["5.7"]
+    steps:
+    - uses: swift-actions/setup-swift@v1
+      with:
+        swift-version: ${{ matrix.swift }}
+    - uses: actions/checkout@v3
+    - name: Test
+      run: swift test --parallel
+
+  # Swift versions older than 5.7 don't have builds for ubuntu 22.04. https://www.swift.org/download/ 
+  backcompat-ubuntu-20_04:
+    name: Test Swift ${{ matrix.swift }} on Ubuntu 20.04
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        swift: ["5.4", "5.5", "5.6"]
+    steps:
+    - uses: swift-actions/setup-swift@v1
+      with:
+        swift-version: ${{ matrix.swift }}
+    - uses: actions/checkout@v3
+    - name: Test
+      run: swift test --parallel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,22 +23,27 @@ jobs:
       - name: Run format linting
         run: docker run --rm -v ${{ github.workspace }}:/repo ghcr.io/nicklockwood/swiftformat:latest /repo --lint
 
-  # Disabled until https://github.com/paulofaria/test-reporter is updated to Swift 5.4
   macos:
     name: Build and test on macOS
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set code coverage path 
-      run: echo "codecov_path=$(swift test --show-codecov-path)" >> $GITHUB_ENV
-    - name: Test and publish code coverage to Code Climate
-      uses: paulofaria/codeclimate-action@master
-      env:
-        CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
+    - uses: maxim-lobanov/setup-xcode@v1
       with:
-        downloadUrl: https://github.com/paulofaria/test-reporter/releases/download/0.9.0/test-reporter-0.9.0-darwin-amd64
-        coverageCommand: swift test --parallel --enable-test-discovery --enable-code-coverage
-        coverageLocations: ${{ env.codecov_path }}:lcov-json
+        xcode-version: latest
+    - uses: actions/checkout@v3
+    - name: Build and test
+      run: swift test --parallel --enable-test-discovery --enable-code-coverage
+    - name: Get test coverage html
+      run: llvm-cov show \
+        .build/x86_64-apple-macosx/debug/GraphitiPackageTests.xctest/Contents/MacOS/GraphitiPackageTests \
+        --instr-profile .build/x86_64-apple-macosx/debug/codecov/default.profdata \
+        --format html \
+        --output-dir=.test-coverage
+    - name: Upload test coverage html
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-coverage-report
+        path: .test-coverage
 
   # ubuntu-latest is ubuntu-22.04 currently. Swift versions older than 5.7 don't have builds for 22.04. https://www.swift.org/download/ 
   ubuntu-old:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
       with:
         downloadUrl: https://github.com/paulofaria/test-reporter/releases/download/0.9.0/test-reporter-0.9.0-darwin-amd64
-        coverageCommand: swift test --enable-test-discovery --enable-code-coverage
+        coverageCommand: swift test --parallel --enable-test-discovery --enable-code-coverage
         coverageLocations: ${{ env.codecov_path }}:lcov-json
 
   # ubuntu-latest is ubuntu-22.04 currently. Swift versions older than 5.7 don't have builds for 22.04. https://www.swift.org/download/ 
@@ -54,7 +54,7 @@ jobs:
         swift-version: ${{ matrix.swift }}
     - uses: actions/checkout@v3
     - name: Test
-      run: swift test
+      run: swift test --parallel
 
   ubuntu-latest:
     name: Build ${{ matrix.swift }} on ${{ matrix.os }}
@@ -69,4 +69,4 @@ jobs:
         swift-version: ${{ matrix.swift }}
     - uses: actions/checkout@v3
     - name: Test
-      run: swift test
+      run: swift test --parallel

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 ### SwiftPM ###
 /.build
 /.swiftpm
+
+### CI Artifacts ###
+/.test-coverage


### PR DESCRIPTION
This removes the Code Climate integration, in preference of the llvm-cov HTML output, which is stored as a GitHub artifact