### PR TITLE
Drops Encodable requirement on GraphQL types

### DIFF
--- a/Sources/Graphiti/Connection/Connection.swift
+++ b/Sources/Graphiti/Connection/Connection.swift
@@ -2,7 +2,7 @@ import Foundation
 import GraphQL
 import NIO
 
-public struct Connection<Node: Encodable>: Encodable {
+public struct Connection<Node> {
     public let edges: [Edge<Node>]
     public let pageInfo: PageInfo
 }
@@ -19,7 +19,7 @@ public extension Connection where Node: Identifiable, Node.ID: LosslessStringCon
 }
 
 @available(macOS 10.15, macCatalyst 13.0, iOS 13.0, tvOS 13, watchOS 6.0, *) // For Identifiable
-public extension EventLoopFuture where Value: Sequence, Value.Element: Encodable & Identifiable,
+public extension EventLoopFuture where Value: Sequence, Value.Element: Identifiable,
 Value.Element.ID: LosslessStringConvertible {
     func connection(from arguments: Paginatable) -> EventLoopFuture<Connection<Value.Element>> {
         connection(from: arguments, makeCursor: Connection<Value.Element>.cursor)
@@ -36,7 +36,7 @@ Value.Element.ID: LosslessStringConvertible {
     }
 }
 
-public extension EventLoopFuture where Value: Sequence, Value.Element: Encodable {
+public extension EventLoopFuture where Value: Sequence {
     func connection(
         from arguments: Paginatable,
         makeCursor: @escaping (Value.Element) throws -> String
@@ -66,7 +66,7 @@ public extension EventLoopFuture where Value: Sequence, Value.Element: Encodable
 }
 
 @available(macOS 10.15, macCatalyst 13.0, iOS 13.0, tvOS 13, watchOS 6.0, *) // For Identifiable
-public extension Sequence where Element: Encodable & Identifiable,
+public extension Sequence where Element: Identifiable,
 Element.ID: LosslessStringConvertible {
     func connection(from arguments: Paginatable) throws -> Connection<Element> {
         try connection(from: arguments, makeCursor: Connection<Element>.cursor)
@@ -81,7 +81,7 @@ Element.ID: LosslessStringConvertible {
     }
 }
 
-public extension Sequence where Element: Encodable {
+public extension Sequence {
     func connection(
         from arguments: Paginatable,
         makeCursor: @escaping (Element) throws -> String
@@ -120,7 +120,7 @@ func connect<Node>(
     to elements: [Node],
     arguments: PaginationArguments,
     makeCursor: @escaping (Node) throws -> String
-) throws -> Connection<Node> where Node: Encodable {
+) throws -> Connection<Node> {
     let edges = try elements.map { element in
         // swiftformat:disable:next hoistTry
         Edge<Node>(node: element, cursor: try makeCursor(element))
@@ -140,7 +140,7 @@ func connect<Node>(
     )
 }
 
-func slicingCursor<Node: Encodable>(
+func slicingCursor<Node>(
     edges: [Edge<Node>],
     arguments: PaginationArguments
 ) -> ArraySlice<Edge<Node>> {
@@ -166,7 +166,7 @@ func slicingCursor<Node: Encodable>(
     return edges
 }
 
-func slicingCount<Node: Encodable>(
+func slicingCount<Node>(
     edges: ArraySlice<Edge<Node>>,
     arguments: PaginationArguments
 ) throws -> [Edge<Node>] {
@@ -195,7 +195,7 @@ func slicingCount<Node: Encodable>(
     return Array(edges)
 }
 
-func hasPreviousPage<Node: Encodable>(
+func hasPreviousPage<Node>(
     edges: ArraySlice<Edge<Node>>,
     arguments: PaginationArguments
 ) -> Bool {
@@ -206,7 +206,7 @@ func hasPreviousPage<Node: Encodable>(
     return false
 }
 
-func hasNextPage<Node: Encodable>(
+func hasNextPage<Node>(
     edges: ArraySlice<Edge<Node>>,
     arguments: PaginationArguments
 ) -> Bool {

--- a/Sources/Graphiti/Connection/ConnectionType.swift
+++ b/Sources/Graphiti/Connection/ConnectionType.swift
@@ -3,7 +3,7 @@ import GraphQL
 public final class ConnectionType<
     Resolver,
     Context,
-    ObjectType: Encodable
+    ObjectType
 >: TypeComponent<
     Resolver,
     Context

--- a/Sources/Graphiti/Connection/Edge.swift
+++ b/Sources/Graphiti/Connection/Edge.swift
@@ -1,10 +1,10 @@
 protocol Edgeable {
-    associatedtype Node: Encodable
+    associatedtype Node
     var node: Node { get }
     var cursor: String { get }
 }
 
-public struct Edge<Node: Encodable>: Edgeable, Encodable {
+public struct Edge<Node>: Edgeable {
     public let node: Node
     public let cursor: String
 }

--- a/Sources/Graphiti/Definition/Reflection.swift
+++ b/Sources/Graphiti/Definition/Reflection.swift
@@ -4,6 +4,7 @@ public enum Reflection {
         return description.hasSuffix("Protocol")
     }
 
+    @available(*, deprecated, message: "No longer used")
     public static func isEncodable(type: Any.Type) -> Bool {
         if isProtocol(type: type) {
             return true

--- a/Sources/Graphiti/Definition/TypeProvider.swift
+++ b/Sources/Graphiti/Definition/TypeProvider.swift
@@ -86,16 +86,6 @@ extension TypeProvider {
     }
 
     func getOutputType(from type: Any.Type, field: String) throws -> GraphQLOutputType {
-        // TODO: Remove this when Reflection error is fixed
-        guard Reflection.isEncodable(type: type) else {
-            throw GraphQLError(
-                message:
-                // TODO: Add field type and use "type.field" format.
-                "Cannot use type \"\(type)\" for field \"\(field)\". " +
-                    "Type does not conform to \"Encodable\"."
-            )
-        }
-
         let graphQLType: GraphQLType
 
         do {

--- a/Sources/Graphiti/Field/Field/Field.swift
+++ b/Sources/Graphiti/Field/Field/Field.swift
@@ -196,7 +196,11 @@ public extension Field {
 
 // MARK: SyncResolve Initializers
 
+// '@_disfavoredOverload' is included below because otherwise `SimpleAsyncResolve` initializers also match this signature, causing the
+// calls to be ambiguous. We prefer that if an EventLoopFuture is returned from the resolve, that `SimpleAsyncResolve` is matched.
+
 public extension Field {
+    @_disfavoredOverload
     convenience init(
         _ name: String,
         at function: @escaping SyncResolve<ObjectType, Context, Arguments, FieldType>,
@@ -205,6 +209,7 @@ public extension Field {
         self.init(name: name, arguments: [argument()], syncResolve: function)
     }
 
+    @_disfavoredOverload
     convenience init(
         _ name: String,
         at function: @escaping SyncResolve<ObjectType, Context, Arguments, FieldType>,
@@ -216,6 +221,7 @@ public extension Field {
 }
 
 public extension Field {
+    @_disfavoredOverload
     convenience init<ResolveType>(
         _ name: String,
         at function: @escaping SyncResolve<ObjectType, Context, Arguments, ResolveType>,
@@ -225,6 +231,7 @@ public extension Field {
         self.init(name: name, arguments: [argument()], syncResolve: function)
     }
 
+    @_disfavoredOverload
     convenience init<ResolveType>(
         _ name: String,
         at function: @escaping SyncResolve<ObjectType, Context, Arguments, ResolveType>,

--- a/Sources/Graphiti/Field/Field/Field.swift
+++ b/Sources/Graphiti/Field/Field/Field.swift
@@ -112,7 +112,7 @@ public class Field<ObjectType, Context, FieldType, Arguments: Decodable>: FieldC
 
 // MARK: AsyncResolve Initializers
 
-public extension Field where FieldType: Encodable {
+public extension Field {
     convenience init(
         _ name: String,
         at function: @escaping AsyncResolve<ObjectType, Context, Arguments, FieldType>,
@@ -154,7 +154,7 @@ public extension Field {
 
 // MARK: SimpleAsyncResolve Initializers
 
-public extension Field where FieldType: Encodable {
+public extension Field {
     convenience init(
         _ name: String,
         at function: @escaping SimpleAsyncResolve<ObjectType, Context, Arguments, FieldType>,
@@ -196,7 +196,7 @@ public extension Field {
 
 // MARK: SyncResolve Initializers
 
-public extension Field where FieldType: Encodable {
+public extension Field {
     convenience init(
         _ name: String,
         at function: @escaping SyncResolve<ObjectType, Context, Arguments, FieldType>,
@@ -298,7 +298,7 @@ public extension Field where Arguments == NoArguments {
 
     // MARK: ConcurrentResolve Initializers
 
-    public extension Field where FieldType: Encodable {
+    public extension Field {
         @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
         convenience init(
             _ name: String,

--- a/Sources/Graphiti/Input/Input.swift
+++ b/Sources/Graphiti/Input/Input.swift
@@ -3,7 +3,7 @@ import GraphQL
 public final class Input<
     Resolver,
     Context,
-    InputObjectType: Decodable
+    InputObjectType
 >: TypeComponent<
     Resolver,
     Context

--- a/Sources/Graphiti/Subscription/SubscribeField.swift
+++ b/Sources/Graphiti/Subscription/SubscribeField.swift
@@ -491,7 +491,11 @@ public extension SubscriptionField {
 
 // MARK: SyncResolve Initializers
 
+// '@_disfavoredOverload' is included below because otherwise `SimpleAsyncResolve` initializers also match this signature, causing the
+// calls to be ambiguous. We prefer that if an EventLoopFuture is returned from the resolve, that `SimpleAsyncResolve` is matched.
+
 public extension SubscriptionField {
+    @_disfavoredOverload
     convenience init(
         _ name: String,
         at function: @escaping SyncResolve<SourceEventType, Context, Arguments, FieldType>,
@@ -511,6 +515,7 @@ public extension SubscriptionField {
         )
     }
 
+    @_disfavoredOverload
     convenience init(
         _ name: String,
         at function: @escaping SyncResolve<SourceEventType, Context, Arguments, FieldType>,
@@ -528,6 +533,7 @@ public extension SubscriptionField {
 }
 
 public extension SubscriptionField {
+    @_disfavoredOverload
     convenience init(
         _ name: String,
         as: FieldType.Type,
@@ -542,6 +548,7 @@ public extension SubscriptionField {
         self.init(name: name, arguments: [argument()], as: `as`, syncSubscribe: subFunc)
     }
 
+    @_disfavoredOverload
     convenience init(
         _ name: String,
         as: FieldType.Type,
@@ -557,6 +564,7 @@ public extension SubscriptionField {
         self.init(name: name, arguments: arguments(), as: `as`, syncSubscribe: subFunc)
     }
 
+    @_disfavoredOverload
     convenience init<ResolveType>(
         _ name: String,
         at function: @escaping SyncResolve<SourceEventType, Context, Arguments, ResolveType>,
@@ -577,6 +585,7 @@ public extension SubscriptionField {
         )
     }
 
+    @_disfavoredOverload
     convenience init<ResolveType>(
         _ name: String,
         at function: @escaping SyncResolve<SourceEventType, Context, Arguments, ResolveType>,

--- a/Sources/Graphiti/Subscription/SubscribeField.swift
+++ b/Sources/Graphiti/Subscription/SubscribeField.swift
@@ -263,7 +263,7 @@ public class SubscriptionField<
 
 // MARK: AsyncResolve Initializers
 
-public extension SubscriptionField where FieldType: Encodable {
+public extension SubscriptionField {
     convenience init(
         _ name: String,
         at function: @escaping AsyncResolve<SourceEventType, Context, Arguments, FieldType>,
@@ -376,7 +376,7 @@ public extension SubscriptionField {
 
 // MARK: SimpleAsyncResolve Initializers
 
-public extension SubscriptionField where FieldType: Encodable {
+public extension SubscriptionField {
     convenience init(
         _ name: String,
         at function: @escaping SimpleAsyncResolve<SourceEventType, Context, Arguments, FieldType>,
@@ -491,7 +491,7 @@ public extension SubscriptionField {
 
 // MARK: SyncResolve Initializers
 
-public extension SubscriptionField where FieldType: Encodable {
+public extension SubscriptionField {
     convenience init(
         _ name: String,
         at function: @escaping SyncResolve<SourceEventType, Context, Arguments, FieldType>,
@@ -680,7 +680,7 @@ public extension SubscriptionField {
 
     // MARK: ConcurrentResolve Initializers
 
-    public extension SubscriptionField where FieldType: Encodable {
+    public extension SubscriptionField {
         @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
         convenience init(
             _ name: String,

--- a/Sources/Graphiti/Type/Type.swift
+++ b/Sources/Graphiti/Type/Type.swift
@@ -1,6 +1,6 @@
 import GraphQL
 
-public final class Type<Resolver, Context, ObjectType: Encodable>: TypeComponent<
+public final class Type<Resolver, Context, ObjectType>: TypeComponent<
     Resolver,
     Context
 > {

--- a/Tests/GraphitiTests/ConnectionTests.swift
+++ b/Tests/GraphitiTests/ConnectionTests.swift
@@ -4,7 +4,7 @@ import NIO
 import XCTest
 
 class ConnectionTests: XCTestCase {
-    struct Comment: Codable, Identifiable {
+    struct Comment: Identifiable {
         let id: Int
         let message: String
     }

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
@@ -21,7 +21,7 @@ struct ID: Codable {
     }
 }
 
-struct User: Codable {
+struct User {
     let id: String
     let name: String?
     let friends: [User]?
@@ -53,7 +53,7 @@ struct UserInput: Codable {
     let friends: [UserInput]?
 }
 
-struct UserEvent: Codable {
+struct UserEvent {
     let user: User
 }
 

--- a/Tests/GraphitiTests/ProductAPI/ProductContext.swift
+++ b/Tests/GraphitiTests/ProductAPI/ProductContext.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+// swiftformat:disable:next enumNamespaces
 struct ProductContext {
     static let dimensions = [
         ProductDimension(

--- a/Tests/GraphitiTests/ProductAPI/ProductEntities.swift
+++ b/Tests/GraphitiTests/ProductAPI/ProductEntities.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Graphiti
 
-struct Product: Codable {
+struct Product {
     let id: String
     let sku: String?
     let package: String?
@@ -30,7 +30,7 @@ struct Product: Codable {
     }
 }
 
-struct DeprecatedProduct: Codable {
+struct DeprecatedProduct {
     let sku: String
     let package: String
     let reason: String?
@@ -42,11 +42,11 @@ struct DeprecatedProduct: Codable {
     }
 }
 
-struct ProductVariation: Codable {
+struct ProductVariation {
     let id: String
 }
 
-struct ProductResearch: Codable {
+struct ProductResearch {
     let study: CaseStudy
     let outcome: String?
 
@@ -59,18 +59,18 @@ struct ProductResearch: Codable {
     }
 }
 
-struct CaseStudy: Codable {
+struct CaseStudy {
     let caseNumber: String
     let description: String?
 }
 
-struct ProductDimension: Codable {
+struct ProductDimension {
     let size: String?
     let weight: Float?
     let unit: String?
 }
 
-struct ProductUser: Codable {
+struct ProductUser {
     let email: String
     let name: String?
     let totalProductsCreated: Int?

--- a/Tests/GraphitiTests/ScalarTests.swift
+++ b/Tests/GraphitiTests/ScalarTests.swift
@@ -8,7 +8,7 @@ class ScalarTests: XCTestCase {
     // MARK: Test UUID converts to String as expected
 
     func testUUIDOutput() throws {
-        struct UUIDOutput: Codable {
+        struct UUIDOutput {
             let value: UUID
         }
 
@@ -56,7 +56,7 @@ class ScalarTests: XCTestCase {
     }
 
     func testUUIDArg() throws {
-        struct UUIDOutput: Codable {
+        struct UUIDOutput {
             let value: UUID
         }
 
@@ -110,7 +110,7 @@ class ScalarTests: XCTestCase {
     }
 
     func testUUIDInput() throws {
-        struct UUIDOutput: Codable {
+        struct UUIDOutput {
             let value: UUID
         }
 
@@ -173,7 +173,7 @@ class ScalarTests: XCTestCase {
     // MARK: Test Date scalars convert to String using ISO8601 encoders
 
     func testDateOutput() throws {
-        struct DateOutput: Codable {
+        struct DateOutput {
             let value: Date
         }
 
@@ -226,7 +226,7 @@ class ScalarTests: XCTestCase {
     }
 
     func testDateArg() throws {
-        struct DateOutput: Codable {
+        struct DateOutput {
             let value: Date
         }
 
@@ -285,7 +285,7 @@ class ScalarTests: XCTestCase {
     }
 
     func testDateInput() throws {
-        struct DateOutput: Codable {
+        struct DateOutput {
             let value: Date
         }
 
@@ -353,7 +353,7 @@ class ScalarTests: XCTestCase {
     // MARK: Test a scalar that converts to a single-value Map (StringCodedCoordinate -> String)
 
     func testStringCoordOutput() throws {
-        struct CoordinateOutput: Codable {
+        struct CoordinateOutput {
             let value: StringCodedCoordinate
         }
 
@@ -401,7 +401,7 @@ class ScalarTests: XCTestCase {
     }
 
     func testStringCoordArg() throws {
-        struct CoordinateOutput: Codable {
+        struct CoordinateOutput {
             let value: StringCodedCoordinate
         }
 
@@ -455,7 +455,7 @@ class ScalarTests: XCTestCase {
     }
 
     func testStringCoordInput() throws {
-        struct CoordinateOutput: Codable {
+        struct CoordinateOutput {
             let value: StringCodedCoordinate
         }
 
@@ -518,7 +518,7 @@ class ScalarTests: XCTestCase {
     // MARK: Test a scalar that converts to a multi-value Map (Coordinate -> Dict)
 
     func testDictCoordOutput() throws {
-        struct CoordinateOutput: Codable {
+        struct CoordinateOutput {
             let value: DictCodedCoordinate
         }
 
@@ -570,7 +570,7 @@ class ScalarTests: XCTestCase {
     }
 
     func testDictCoordArg() throws {
-        struct CoordinateOutput: Codable {
+        struct CoordinateOutput {
             let value: DictCodedCoordinate
         }
 
@@ -628,7 +628,7 @@ class ScalarTests: XCTestCase {
     }
 
     func testDictCoordInput() throws {
-        struct CoordinateOutput: Codable {
+        struct CoordinateOutput {
             let value: DictCodedCoordinate
         }
 

--- a/Tests/GraphitiTests/StarWarsAPI/StarWarsEntities.swift
+++ b/Tests/GraphitiTests/StarWarsAPI/StarWarsEntities.swift
@@ -1,19 +1,19 @@
-public enum Episode: String, Codable, CaseIterable {
+public enum Episode: String, CaseIterable, Codable {
     case newHope = "NEWHOPE"
     case empire = "EMPIRE"
     case jedi = "JEDI"
 }
 
-public protocol Character: Codable {
+public protocol Character {
     var id: String { get }
     var name: String { get }
     var friends: [String] { get }
     var appearsIn: [Episode] { get }
 }
 
-public protocol SearchResult: Codable {}
+public protocol SearchResult {}
 
-public struct Planet: SearchResult, Codable {
+public struct Planet: SearchResult {
     public let id: String
     public let name: String
     public let diameter: Int
@@ -22,7 +22,7 @@ public struct Planet: SearchResult, Codable {
     public var residents: [Human]
 }
 
-public struct Human: Character, SearchResult, Codable {
+public struct Human: Character, SearchResult {
     public let id: String
     public let name: String
     public let friends: [String]
@@ -30,7 +30,7 @@ public struct Human: Character, SearchResult, Codable {
     public let homePlanet: Planet
 }
 
-public struct Droid: Character, SearchResult, Codable {
+public struct Droid: Character, SearchResult {
     public let id: String
     public let name: String
     public let friends: [String]

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsQueryTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsQueryTests.swift
@@ -625,7 +625,7 @@ class StarWarsQueryTests: XCTestCase {
     }
 
     func testNonNullableFieldsQuery() throws {
-        struct A: Codable {
+        struct A {
             func nullableA(context _: NoContext, arguments _: NoArguments) -> A? {
                 return A()
             }


### PR DESCRIPTION
This drops unnecessary Codable conformance from GraphQL-injected types. More specifically, output types are never encoded or decoded - only the resulting leaf Scalars are encoded. While this PR removes the restriction that all output types are codable, it still requires Encodability on Scalars and Decodability on Arguments. Decodable conformance is technically removed from Input objects, but typically still enforced through the decodable Argument requirement.

This change is useful if you have a complex, non-codable type that you would like to pass through resolver chains.