### PR TITLE
Adds public inits for all 3 paginatable arguments structs

### DIFF
--- a/Sources/Graphiti/Connection/PagniationArguments/BackwardPaginationArguments.swift
+++ b/Sources/Graphiti/Connection/PagniationArguments/BackwardPaginationArguments.swift
@@ -6,7 +6,7 @@ public protocol BackwardPaginatable: Decodable {
 public struct BackwardPaginationArguments: BackwardPaginatable {
     public let last: Int?
     public let before: String?
-    
+
     public init(last: Int?, before: String?) {
         self.last = last
         self.before = before

--- a/Sources/Graphiti/Connection/PagniationArguments/BackwardPaginationArguments.swift
+++ b/Sources/Graphiti/Connection/PagniationArguments/BackwardPaginationArguments.swift
@@ -6,4 +6,9 @@ public protocol BackwardPaginatable: Decodable {
 public struct BackwardPaginationArguments: BackwardPaginatable {
     public let last: Int?
     public let before: String?
+    
+    public init(last: Int?, before: String?) {
+        self.last = last
+        self.before = before
+    }
 }

--- a/Sources/Graphiti/Connection/PagniationArguments/ForwardPaginationArguments.swift
+++ b/Sources/Graphiti/Connection/PagniationArguments/ForwardPaginationArguments.swift
@@ -6,7 +6,7 @@ public protocol ForwardPaginatable: Decodable {
 public struct ForwardPaginationArguments: ForwardPaginatable {
     public let first: Int?
     public let after: String?
-    
+
     public init(first: Int?, after: String?) {
         self.first = first
         self.after = after

--- a/Sources/Graphiti/Connection/PagniationArguments/ForwardPaginationArguments.swift
+++ b/Sources/Graphiti/Connection/PagniationArguments/ForwardPaginationArguments.swift
@@ -6,4 +6,9 @@ public protocol ForwardPaginatable: Decodable {
 public struct ForwardPaginationArguments: ForwardPaginatable {
     public let first: Int?
     public let after: String?
+    
+    public init(first: Int?, after: String?) {
+        self.first = first
+        self.after = after
+    }
 }

--- a/Sources/Graphiti/Connection/PagniationArguments/PaginationArguments.swift
+++ b/Sources/Graphiti/Connection/PagniationArguments/PaginationArguments.swift
@@ -5,6 +5,13 @@ public struct PaginationArguments: Paginatable {
     public let last: Int?
     public let after: String?
     public let before: String?
+    
+    public init(first: Int? = nil, last: Int? = nil, after: String? = nil, before: String? = nil) {
+        self.first = first
+        self.last = last
+        self.after = after
+        self.before = before
+    }
 
     init(_ arguments: Paginatable) {
         first = arguments.first

--- a/Sources/Graphiti/Connection/PagniationArguments/PaginationArguments.swift
+++ b/Sources/Graphiti/Connection/PagniationArguments/PaginationArguments.swift
@@ -5,7 +5,7 @@ public struct PaginationArguments: Paginatable {
     public let last: Int?
     public let after: String?
     public let before: String?
-    
+
     public init(first: Int? = nil, last: Int? = nil, after: String? = nil, before: String? = nil) {
         self.first = first
         self.last = last


### PR DESCRIPTION
It would be nice to be able to instantiate the `ForwardPaginationArguments`, `BackwardPaginationArguments`, and `PaginationArguments` outside of the package (in tests, etc).

This pull request adds these public inits.