### PR TITLE
Fixes hello world query type to ID

### DIFF
--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
@@ -271,7 +271,7 @@ class HelloWorldTests: XCTestCase {
         wait(for: [expectationB], timeout: 10)
 
         query = """
-        query Query($id: String!) {
+        query Query($id: ID!) {
             id(id: $id)
         }
         """


### PR DESCRIPTION
Simple fix to a test to use the correct variable type.

This was flagged by the new validation rules brought into GraphQL in https://github.com/GraphQLSwift/GraphQL/pull/135