### PR TITLE
Fix exception thrown when two classes with the same name (but not the same fully-qualified name) are registered in a Schema

### DIFF
--- a/Sources/Graphiti/Definition/AnyType.swift
+++ b/Sources/Graphiti/Definition/AnyType.swift
@@ -10,6 +10,6 @@ final class AnyType: Hashable {
     }
 
     static func == (lhs: AnyType, rhs: AnyType) -> Bool {
-        return lhs.hashValue == rhs.hashValue
+        return lhs.type == rhs.type
     }
 }


### PR DESCRIPTION
> EDIT: There is no crash, only an exception thrown

### Description

This fix aims to mitigate exception thrown when registering two types that have the same name but not the same fully qualified name.

```swift
enum UserView {
  struct Public {
    // ...
  }

  struct Private {
    // ...
  }
}

enum OrganizationView {
  struct Public {
    // ...
  }
}
```

Since the actual implementation of AnyType.hashValue uses `String(describing:)` to get the type name, both `String(describing: UserView.Public.self)` and `String(describing: OrganizationView.Public.self)` would return `"Public"`:
https://github.com/GraphQLSwift/Graphiti/blob/927ebb174825cf8188190fb9eb38d9de84806256/Sources/Graphiti/Definition/AnyType.swift#L8-L10

The same happen for types that aren't nested but in different modules – such as two libraries/frameworks/SPM-targets – as long as the type name themselves are the same.

### Proposed solution

With my limited knowledge of the Graphiti codebase, I can see two ways to fix this (always happy to discuss a better implementation with guidance from the maintainers):

1. Use `String(reflecting:)` to compute the hash code (which returns the fully qualified class name, i.e. "NameOfTheSwiftModule.UserView.Public").
2. Change the equality operator implementation to compare the types instead of the hash code.

I preferred solution 2 as the [`String(reflecting:)` documentation](https://developer.apple.com/documentation/swift/string/init(reflecting:)) states ___suitable for debugging___. Therefore I avoid building production ready solutions on this.

### Swift version

swift-driver version: 1.109.2 Apple Swift version 6.0 (swiftlang-6.0.0.3.300 clang-1600.0.20.10)
Target: arm64-apple-macosx15.0