### PR TITLE
Remove expectations from tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 ### CI Artifacts ###
 /.test-coverage
+
+# VS Code
+.vscode/

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
@@ -166,11 +166,11 @@ import XCTest
             }
             """
 
-            let subscriptionResult = try api.subscribe(
+            let subscriptionResult = try await api.subscribe(
                 request: request,
                 context: api.context,
                 on: group
-            ).wait()
+            )
             guard let subscription = subscriptionResult.stream else {
                 XCTFail(subscriptionResult.errors.description)
                 return

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
@@ -166,266 +166,179 @@ class HelloWorldTests: XCTestCase {
     }
 
     func testHello() throws {
-        let query = "{ hello }"
-        let expected = GraphQLResult(data: ["hello": "world"])
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: api.context,
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
+        XCTAssertEqual(
+            try api.execute(
+                request: "{ hello }",
+                context: api.context,
+                on: group
+            ).wait(),
+            GraphQLResult(data: ["hello": "world"])
+        )
     }
 
     func testFutureHello() throws {
-        let query = "{ futureHello }"
-        let expected = GraphQLResult(data: ["futureHello": "world"])
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: api.context,
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
+        XCTAssertEqual(
+            try api.execute(
+                request: "{ futureHello }",
+                context: api.context,
+                on: group
+            ).wait(),
+            GraphQLResult(data: ["futureHello": "world"])
+        )
     }
 
     func testBoyhowdy() throws {
-        let query = "{ boyhowdy }"
-
-        let expected = GraphQLResult(
-            errors: [
-                GraphQLError(
-                    message: "Cannot query field \"boyhowdy\" on type \"Query\".",
-                    locations: [SourceLocation(line: 1, column: 3)]
-                ),
-            ]
+        XCTAssertEqual(
+            try api.execute(
+                request: "{ boyhowdy }",
+                context: api.context,
+                on: group
+            ).wait(),
+            GraphQLResult(
+                errors: [
+                    GraphQLError(
+                        message: "Cannot query field \"boyhowdy\" on type \"Query\".",
+                        locations: [SourceLocation(line: 1, column: 3)]
+                    ),
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: api.context,
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testScalar() throws {
-        var query: String
-        var expected = GraphQLResult(data: ["float": 4.0])
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query Query($float: Float!) {
+                    float(float: $float)
+                }
+                """,
+                context: api.context,
+                on: group,
+                variables: ["float": 4]
+            ).wait(),
+            GraphQLResult(data: ["float": 4.0])
+        )
 
-        query = """
-        query Query($float: Float!) {
-            float(float: $float)
-        }
-        """
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query Query {
+                    float(float: 4)
+                }
+                """,
+                context: api.context,
+                on: group
+            ).wait(),
+            GraphQLResult(data: ["float": 4.0])
+        )
 
-        let expectationA = XCTestExpectation()
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query Query($id: ID!) {
+                    id(id: $id)
+                }
+                """,
+                context: api.context,
+                on: group,
+                variables: ["id": "85b8d502-8190-40ab-b18f-88edd297d8b6"]
+            ).wait(),
+            GraphQLResult(data: ["id": "85b8d502-8190-40ab-b18f-88edd297d8b6"])
+        )
 
-        api.execute(
-            request: query,
-            context: api.context,
-            on: group,
-            variables: ["float": 4]
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectationA.fulfill()
-        }
-
-        wait(for: [expectationA], timeout: 10)
-
-        query = """
-        query Query {
-            float(float: 4)
-        }
-        """
-
-        let expectationB = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: api.context,
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectationB.fulfill()
-        }
-
-        wait(for: [expectationB], timeout: 10)
-
-        query = """
-        query Query($id: ID!) {
-            id(id: $id)
-        }
-        """
-
-        expected = GraphQLResult(data: ["id": "85b8d502-8190-40ab-b18f-88edd297d8b6"])
-
-        let expectationC = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: api.context,
-            on: group,
-            variables: ["id": "85b8d502-8190-40ab-b18f-88edd297d8b6"]
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectationC.fulfill()
-        }
-
-        wait(for: [expectationC], timeout: 10)
-
-        query = """
-        query Query {
-            id(id: "85b8d502-8190-40ab-b18f-88edd297d8b6")
-        }
-        """
-
-        let expectationD = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: api.context,
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectationD.fulfill()
-        }
-
-        wait(for: [expectationD], timeout: 10)
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query Query {
+                    id(id: "85b8d502-8190-40ab-b18f-88edd297d8b6")
+                }
+                """,
+                context: api.context,
+                on: group
+            ).wait(),
+            GraphQLResult(data: ["id": "85b8d502-8190-40ab-b18f-88edd297d8b6"])
+        )
     }
 
     func testInput() throws {
-        let mutation = """
-        mutation addUser($user: UserInput!) {
-            addUser(user: $user) {
-                id,
-                name
-            }
-        }
-        """
-
-        let variables: [String: Map] = ["user": ["id": "123", "name": "bob"]]
-
-        let expected = GraphQLResult(
-            data: ["addUser": ["id": "123", "name": "bob"]]
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                mutation addUser($user: UserInput!) {
+                    addUser(user: $user) {
+                        id,
+                        name
+                    }
+                }
+                """,
+                context: api.context,
+                on: group,
+                variables: ["user": ["id": "123", "name": "bob"]]
+            ).wait(),
+            GraphQLResult(
+                data: ["addUser": ["id": "123", "name": "bob"]]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: mutation,
-            context: api.context,
-            on: group,
-            variables: variables
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testInputRequest() throws {
-        let mutation = """
-        mutation addUser($user: UserInput!) {
-            addUser(user: $user) {
-                id,
-                name
-            }
-        }
-        """
-        let variables: [String: Map] = ["user": ["id": "123", "name": "bob"]]
-
-        let request = GraphQLRequest(
-            query: mutation,
-            variables: variables
+        XCTAssertEqual(
+            try api.execute(
+                request: GraphQLRequest(
+                    query: """
+                    mutation addUser($user: UserInput!) {
+                        addUser(user: $user) {
+                            id,
+                            name
+                        }
+                    }
+                    """,
+                    variables: ["user": ["id": "123", "name": "bob"]]
+                ),
+                context: api.context,
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: ["addUser": ["id": "123", "name": "bob"]]
+            )
         )
-
-        let expected = GraphQLResult(
-            data: ["addUser": ["id": "123", "name": "bob"]]
-        )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: request,
-            context: api.context,
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testInputRecursive() throws {
-        let mutation = """
-        mutation addUser($user: UserInput!) {
-            addUser(user: $user) {
-                id,
-                name,
-                friends {
-                    id,
-                    name
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                mutation addUser($user: UserInput!) {
+                    addUser(user: $user) {
+                        id,
+                        name,
+                        friends {
+                            id,
+                            name
+                        }
+                    }
                 }
-            }
-        }
-        """
-
-        let variables: [String: Map] =
-            ["user": ["id": "123", "name": "bob", "friends": [["id": "124", "name": "jeff"]]]]
-
-        let expected = GraphQLResult(
-            data: ["addUser": [
-                "id": "123",
-                "name": "bob",
-                "friends": [["id": "124", "name": "jeff"]],
-            ]]
+                """,
+                context: api.context,
+                on: group,
+                variables: [
+                    "user": [
+                        "id": "123",
+                        "name": "bob",
+                        "friends": [["id": "124", "name": "jeff"]],
+                    ],
+                ]
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "addUser": [
+                        "id": "123",
+                        "name": "bob",
+                        "friends": [["id": "124", "name": "jeff"]],
+                    ],
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: mutation,
-            context: api.context,
-            on: group,
-            variables: variables
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-    }
-}
-
-extension HelloWorldTests {
-    static var allTests: [(String, (HelloWorldTests) -> () throws -> Void)] {
-        return [
-            ("testHello", testHello),
-            ("testFutureHello", testFutureHello),
-            ("testBoyhowdy", testBoyhowdy),
-            ("testScalar", testScalar),
-            ("testInput", testInput),
-        ]
     }
 }

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
@@ -13,424 +13,268 @@ class StarWarsIntrospectionTests: XCTestCase {
     }
 
     func testIntrospectionTypeQuery() throws {
-        let query = """
-        query IntrospectionTypeQuery {
-            __schema {
-                types {
-                    name
-                }
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "__schema": [
-                    "types": [
-                        [
-                            "name": "Boolean",
-                        ],
-                        [
-                            "name": "Character",
-                        ],
-                        [
-                            "name": "Droid",
-                        ],
-                        [
-                            "name": "Episode",
-                        ],
-                        [
-                            "name": "Human",
-                        ],
-                        [
-                            "name": "Int",
-                        ],
-                        [
-                            "name": "Planet",
-                        ],
-                        [
-                            "name": "Query",
-                        ],
-                        [
-                            "name": "SearchResult",
-                        ],
-                        [
-                            "name": "String",
-                        ],
-                        [
-                            "name": "__Directive",
-                        ],
-                        [
-                            "name": "__DirectiveLocation",
-                        ],
-                        [
-                            "name": "__EnumValue",
-                        ],
-                        [
-                            "name": "__Field",
-                        ],
-                        [
-                            "name": "__InputValue",
-                        ],
-                        [
-                            "name": "__Schema",
-                        ],
-                        [
-                            "name": "__Type",
-                        ],
-                        [
-                            "name": "__TypeKind",
-                        ],
-                    ],
-                ],
-            ]
-        )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-    }
-
-    func testIntrospectionQueryTypeQuery() throws {
-        let query = """
-        query IntrospectionQueryTypeQuery {
-            __schema {
-                queryType {
-                    name
-                }
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "__schema": [
-                    "queryType": [
-                        "name": "Query",
-                    ],
-                ],
-            ]
-        )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-    }
-
-    func testIntrospectionDroidTypeQuery() throws {
-        let query = """
-        query IntrospectionDroidTypeQuery {
-            __type(name: \"Droid\") {
-                name
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "__type": [
-                    "name": "Droid",
-                ],
-            ]
-        )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-    }
-
-    func testIntrospectionDroidKindQuery() throws {
-        let query = """
-        query IntrospectionDroidKindQuery {
-            __type(name: \"Droid\") {
-                name
-                kind
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "__type": [
-                    "name": "Droid",
-                    "kind": "OBJECT",
-                ],
-            ]
-        )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-    }
-
-    func testIntrospectionCharacterKindQuery() throws {
-        let query = """
-        query IntrospectionCharacterKindQuery {
-            __type(name: \"Character\") {
-                name
-                kind
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "__type": [
-                    "name": "Character",
-                    "kind": "INTERFACE",
-                ],
-            ]
-        )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-    }
-
-    func testIntrospectionDroidFieldsQuery() throws {
-        let query = """
-        query IntrospectionDroidFieldsQuery {
-            __type(name: \"Droid\") {
-                name
-                fields {
-                    name
-                    type {
-                        name
-                        kind
-                    }
-                }
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "__type": [
-                    "name": "Droid",
-                    "fields": [
-                        [
-                            "name": "appearsIn",
-                            "type": [
-                                "name": nil,
-                                "kind": "NON_NULL",
-                            ],
-                        ],
-                        [
-                            "name": "friends",
-                            "type": [
-                                "name": nil,
-                                "kind": "NON_NULL",
-                            ],
-                        ],
-                        [
-                            "name": "id",
-                            "type": [
-                                "name": nil,
-                                "kind": "NON_NULL",
-                            ],
-                        ],
-                        [
-                            "name": "name",
-                            "type": [
-                                "name": nil,
-                                "kind": "NON_NULL",
-                            ],
-                        ],
-                        [
-                            "name": "primaryFunction",
-                            "type": [
-                                "name": nil,
-                                "kind": "NON_NULL",
-                            ],
-                        ],
-                        [
-                            "name": "secretBackstory",
-                            "type": [
-                                "name": "String",
-                                "kind": "SCALAR",
-                            ],
-                        ],
-                    ],
-                ],
-            ]
-        )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-    }
-
-    func testIntrospectionDroidNestedFieldsQuery() throws {
-        let query = """
-        query IntrospectionDroidNestedFieldsQuery {
-            __type(name: \"Droid\") {
-                name
-                fields {
-                    name
-                    type {
-                        name
-                        kind
-                        ofType {
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query IntrospectionTypeQuery {
+                    __schema {
+                        types {
                             name
-                            kind
                         }
                     }
                 }
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "__type": [
-                    "name": "Droid",
-                    "fields": [
-                        [
-                            "name": "appearsIn",
-                            "type": [
-                                "name": nil,
-                                "kind": "NON_NULL",
-                                "ofType": [
-                                    "name": nil,
-                                    "kind": "LIST",
-                                ],
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "__schema": [
+                        "types": [
+                            [
+                                "name": "Boolean",
                             ],
-                        ],
-                        [
-                            "name": "friends",
-                            "type": [
-                                "name": nil,
-                                "kind": "NON_NULL",
-                                "ofType": [
-                                    "name": nil,
-                                    "kind": "LIST",
-                                ],
+                            [
+                                "name": "Character",
                             ],
-                        ],
-                        [
-                            "name": "id",
-                            "type": [
-                                "name": nil,
-                                "kind": "NON_NULL",
-                                "ofType": [
-                                    "name": "String",
-                                    "kind": "SCALAR",
-                                ],
+                            [
+                                "name": "Droid",
                             ],
-                        ],
-                        [
-                            "name": "name",
-                            "type": [
-                                "name": nil,
-                                "kind": "NON_NULL",
-                                "ofType": [
-                                    "name": "String",
-                                    "kind": "SCALAR",
-                                ],
+                            [
+                                "name": "Episode",
                             ],
-                        ],
-                        [
-                            "name": "primaryFunction",
-                            "type": [
-                                "name": nil,
-                                "kind": "NON_NULL",
-                                "ofType": [
-                                    "name": "String",
-                                    "kind": "SCALAR",
-                                ],
+                            [
+                                "name": "Human",
                             ],
-                        ],
-                        [
-                            "name": "secretBackstory",
-                            "type": [
+                            [
+                                "name": "Int",
+                            ],
+                            [
+                                "name": "Planet",
+                            ],
+                            [
+                                "name": "Query",
+                            ],
+                            [
+                                "name": "SearchResult",
+                            ],
+                            [
                                 "name": "String",
-                                "kind": "SCALAR",
-                                "ofType": nil,
+                            ],
+                            [
+                                "name": "__Directive",
+                            ],
+                            [
+                                "name": "__DirectiveLocation",
+                            ],
+                            [
+                                "name": "__EnumValue",
+                            ],
+                            [
+                                "name": "__Field",
+                            ],
+                            [
+                                "name": "__InputValue",
+                            ],
+                            [
+                                "name": "__Schema",
+                            ],
+                            [
+                                "name": "__Type",
+                            ],
+                            [
+                                "name": "__TypeKind",
                             ],
                         ],
                     ],
-                ],
-            ]
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
-    func testIntrospectionFieldArgsQuery() throws {
-        let query = """
-        query IntrospectionFieldArgsQuery {
-            __schema {
-                queryType {
-                    fields {
-                        name
-                        args {
+    func testIntrospectionQueryTypeQuery() throws {
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query IntrospectionQueryTypeQuery {
+                    __schema {
+                        queryType {
                             name
-                            description
+                        }
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "__schema": [
+                        "queryType": [
+                            "name": "Query",
+                        ],
+                    ],
+                ]
+            )
+        )
+    }
+
+    func testIntrospectionDroidTypeQuery() throws {
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query IntrospectionDroidTypeQuery {
+                    __type(name: \"Droid\") {
+                        name
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "__type": [
+                        "name": "Droid",
+                    ],
+                ]
+            )
+        )
+    }
+
+    func testIntrospectionDroidKindQuery() throws {
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query IntrospectionDroidKindQuery {
+                    __type(name: \"Droid\") {
+                        name
+                        kind
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "__type": [
+                        "name": "Droid",
+                        "kind": "OBJECT",
+                    ],
+                ]
+            )
+        )
+    }
+
+    func testIntrospectionCharacterKindQuery() throws {
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query IntrospectionCharacterKindQuery {
+                    __type(name: \"Character\") {
+                        name
+                        kind
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "__type": [
+                        "name": "Character",
+                        "kind": "INTERFACE",
+                    ],
+                ]
+            )
+        )
+    }
+
+    func testIntrospectionDroidFieldsQuery() throws {
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query IntrospectionDroidFieldsQuery {
+                    __type(name: \"Droid\") {
+                        name
+                        fields {
+                            name
+                            type {
+                                name
+                                kind
+                            }
+                        }
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "__type": [
+                        "name": "Droid",
+                        "fields": [
+                            [
+                                "name": "appearsIn",
+                                "type": [
+                                    "name": nil,
+                                    "kind": "NON_NULL",
+                                ],
+                            ],
+                            [
+                                "name": "friends",
+                                "type": [
+                                    "name": nil,
+                                    "kind": "NON_NULL",
+                                ],
+                            ],
+                            [
+                                "name": "id",
+                                "type": [
+                                    "name": nil,
+                                    "kind": "NON_NULL",
+                                ],
+                            ],
+                            [
+                                "name": "name",
+                                "type": [
+                                    "name": nil,
+                                    "kind": "NON_NULL",
+                                ],
+                            ],
+                            [
+                                "name": "primaryFunction",
+                                "type": [
+                                    "name": nil,
+                                    "kind": "NON_NULL",
+                                ],
+                            ],
+                            [
+                                "name": "secretBackstory",
+                                "type": [
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            )
+        )
+    }
+
+    func testIntrospectionDroidNestedFieldsQuery() throws {
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query IntrospectionDroidNestedFieldsQuery {
+                    __type(name: \"Droid\") {
+                        name
+                        fields {
+                            name
                             type {
                                 name
                                 kind
@@ -439,154 +283,222 @@ class StarWarsIntrospectionTests: XCTestCase {
                                     kind
                                 }
                             }
-                            defaultValue
-                         }
+                        }
                     }
                 }
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "__schema": [
-                    "queryType": [
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "__type": [
+                        "name": "Droid",
                         "fields": [
                             [
-                                "name": "droid",
-                                "args": [
-                                    [
-                                        "name": "id",
-                                        "description": "Id of the droid.",
-                                        "type": [
-                                            "name": nil,
-                                            "kind": "NON_NULL",
-                                            "ofType": [
-                                                "name": "String",
-                                                "kind": "SCALAR",
-                                            ],
-                                        ],
-                                        "defaultValue": nil,
+                                "name": "appearsIn",
+                                "type": [
+                                    "name": nil,
+                                    "kind": "NON_NULL",
+                                    "ofType": [
+                                        "name": nil,
+                                        "kind": "LIST",
                                     ],
                                 ],
                             ],
                             [
-                                "name": "hero",
-                                "args": [
-                                    [
-                                        "name": "episode",
-                                        "description": "If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.",
-                                        "type": [
-                                            "name": "Episode",
-                                            "kind": "ENUM",
-                                            "ofType": nil,
-                                        ],
-                                        "defaultValue": nil,
+                                "name": "friends",
+                                "type": [
+                                    "name": nil,
+                                    "kind": "NON_NULL",
+                                    "ofType": [
+                                        "name": nil,
+                                        "kind": "LIST",
                                     ],
                                 ],
                             ],
                             [
-                                "name": "human",
-                                "args": [
-                                    [
-                                        "name": "id",
-                                        "description": "Id of the human.",
-                                        "type": [
-                                            "name": nil,
-                                            "kind": "NON_NULL",
-                                            "ofType": [
-                                                "name": "String",
-                                                "kind": "SCALAR",
-                                            ],
-                                        ],
-                                        "defaultValue": nil,
+                                "name": "id",
+                                "type": [
+                                    "name": nil,
+                                    "kind": "NON_NULL",
+                                    "ofType": [
+                                        "name": "String",
+                                        "kind": "SCALAR",
                                     ],
                                 ],
                             ],
                             [
-                                "name": "search",
-                                "args": [
-                                    [
-                                        "name": "query",
-                                        "description": nil,
-                                        "type": [
-                                            "name": nil,
-                                            "kind": "NON_NULL",
-                                            "ofType": [
-                                                "name": "String",
-                                                "kind": "SCALAR",
+                                "name": "name",
+                                "type": [
+                                    "name": nil,
+                                    "kind": "NON_NULL",
+                                    "ofType": [
+                                        "name": "String",
+                                        "kind": "SCALAR",
+                                    ],
+                                ],
+                            ],
+                            [
+                                "name": "primaryFunction",
+                                "type": [
+                                    "name": nil,
+                                    "kind": "NON_NULL",
+                                    "ofType": [
+                                        "name": "String",
+                                        "kind": "SCALAR",
+                                    ],
+                                ],
+                            ],
+                            [
+                                "name": "secretBackstory",
+                                "type": [
+                                    "name": "String",
+                                    "kind": "SCALAR",
+                                    "ofType": nil,
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            )
+        )
+    }
+
+    func testIntrospectionFieldArgsQuery() throws {
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query IntrospectionFieldArgsQuery {
+                    __schema {
+                        queryType {
+                            fields {
+                                name
+                                args {
+                                    name
+                                    description
+                                    type {
+                                        name
+                                        kind
+                                        ofType {
+                                            name
+                                            kind
+                                        }
+                                    }
+                                    defaultValue
+                                 }
+                            }
+                        }
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "__schema": [
+                        "queryType": [
+                            "fields": [
+                                [
+                                    "name": "droid",
+                                    "args": [
+                                        [
+                                            "name": "id",
+                                            "description": "Id of the droid.",
+                                            "type": [
+                                                "name": nil,
+                                                "kind": "NON_NULL",
+                                                "ofType": [
+                                                    "name": "String",
+                                                    "kind": "SCALAR",
+                                                ],
                                             ],
+                                            "defaultValue": nil,
                                         ],
-                                        "defaultValue": "\"R2-D2\"",
+                                    ],
+                                ],
+                                [
+                                    "name": "hero",
+                                    "args": [
+                                        [
+                                            "name": "episode",
+                                            "description": "If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.",
+                                            "type": [
+                                                "name": "Episode",
+                                                "kind": "ENUM",
+                                                "ofType": nil,
+                                            ],
+                                            "defaultValue": nil,
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    "name": "human",
+                                    "args": [
+                                        [
+                                            "name": "id",
+                                            "description": "Id of the human.",
+                                            "type": [
+                                                "name": nil,
+                                                "kind": "NON_NULL",
+                                                "ofType": [
+                                                    "name": "String",
+                                                    "kind": "SCALAR",
+                                                ],
+                                            ],
+                                            "defaultValue": nil,
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    "name": "search",
+                                    "args": [
+                                        [
+                                            "name": "query",
+                                            "description": nil,
+                                            "type": [
+                                                "name": nil,
+                                                "kind": "NON_NULL",
+                                                "ofType": [
+                                                    "name": "String",
+                                                    "kind": "SCALAR",
+                                                ],
+                                            ],
+                                            "defaultValue": "\"R2-D2\"",
+                                        ],
                                     ],
                                 ],
                             ],
                         ],
                     ],
-                ],
-            ]
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testIntrospectionDroidDescriptionQuery() throws {
-        let query = """
-        query IntrospectionDroidDescriptionQuery {
-            __type(name: \"Droid\") {
-                name
-                description
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "__type": [
-                    "name": "Droid",
-                    "description": "A mechanical creature in the Star Wars universe.",
-                ],
-            ]
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query IntrospectionDroidDescriptionQuery {
+                    __type(name: \"Droid\") {
+                        name
+                        description
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "__type": [
+                        "name": "Droid",
+                        "description": "A mechanical creature in the Star Wars universe.",
+                    ],
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-    }
-}
-
-extension StarWarsIntrospectionTests {
-    static var allTests: [(String, (StarWarsIntrospectionTests) -> () throws -> Void)] {
-        return [
-            ("testIntrospectionTypeQuery", testIntrospectionTypeQuery),
-            ("testIntrospectionQueryTypeQuery", testIntrospectionQueryTypeQuery),
-            ("testIntrospectionDroidTypeQuery", testIntrospectionDroidTypeQuery),
-            ("testIntrospectionDroidKindQuery", testIntrospectionDroidKindQuery),
-            ("testIntrospectionCharacterKindQuery", testIntrospectionCharacterKindQuery),
-            ("testIntrospectionDroidFieldsQuery", testIntrospectionDroidFieldsQuery),
-            ("testIntrospectionDroidNestedFieldsQuery", testIntrospectionDroidNestedFieldsQuery),
-            ("testIntrospectionFieldArgsQuery", testIntrospectionFieldArgsQuery),
-            ("testIntrospectionDroidDescriptionQuery", testIntrospectionDroidDescriptionQuery),
-        ]
     }
 }

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsQueryTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsQueryTests.swift
@@ -12,616 +12,495 @@ class StarWarsQueryTests: XCTestCase {
     }
 
     func testHeroNameQuery() throws {
-        let query = """
-        query HeroNameQuery {
-            hero {
-                name
-            }
-        }
-        """
-
-        let expected = GraphQLResult(data: ["hero": ["name": "R2-D2"]])
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-    }
-
-    func testHeroNameAndFriendsQuery() throws {
-        let query = """
-        query HeroNameAndFriendsQuery {
-            hero {
-                id
-                name
-                friends {
-                    name
-                }
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "hero": [
-                    "id": "2001",
-                    "name": "R2-D2",
-                    "friends": [
-                        ["name": "Luke Skywalker"],
-                        ["name": "Han Solo"],
-                        ["name": "Leia Organa"],
-                    ],
-                ],
-            ]
-        )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-    }
-
-    func testNestedQuery() throws {
-        let query = """
-        query NestedQuery {
-            hero {
-                name
-                friends {
-                    name
-                    appearsIn
-                    friends {
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query HeroNameQuery {
+                    hero {
                         name
                     }
                 }
-            }
-        }
-        """
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(data: ["hero": ["name": "R2-D2"]])
+        )
+    }
 
-        let expected = GraphQLResult(
-            data: [
-                "hero": [
-                    "name": "R2-D2",
-                    "friends": [
-                        [
-                            "name": "Luke Skywalker",
-                            "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
-                            "friends": [
-                                ["name": "Han Solo"],
-                                ["name": "Leia Organa"],
-                                ["name": "C-3PO"],
-                                ["name": "R2-D2"],
-                            ],
+    func testHeroNameAndFriendsQuery() throws {
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query HeroNameAndFriendsQuery {
+                    hero {
+                        id
+                        name
+                        friends {
+                            name
+                        }
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "hero": [
+                        "id": "2001",
+                        "name": "R2-D2",
+                        "friends": [
+                            ["name": "Luke Skywalker"],
+                            ["name": "Han Solo"],
+                            ["name": "Leia Organa"],
                         ],
-                        [
-                            "name": "Han Solo",
-                            "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
-                            "friends": [
-                                ["name": "Luke Skywalker"],
-                                ["name": "Leia Organa"],
-                                ["name": "R2-D2"],
+                    ],
+                ]
+            )
+        )
+    }
+
+    func testNestedQuery() throws {
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query NestedQuery {
+                    hero {
+                        name
+                        friends {
+                            name
+                            appearsIn
+                            friends {
+                                name
+                            }
+                        }
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "hero": [
+                        "name": "R2-D2",
+                        "friends": [
+                            [
+                                "name": "Luke Skywalker",
+                                "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
+                                "friends": [
+                                    ["name": "Han Solo"],
+                                    ["name": "Leia Organa"],
+                                    ["name": "C-3PO"],
+                                    ["name": "R2-D2"],
+                                ],
                             ],
-                        ],
-                        [
-                            "name": "Leia Organa",
-                            "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
-                            "friends": [
-                                ["name": "Luke Skywalker"],
-                                ["name": "Han Solo"],
-                                ["name": "C-3PO"],
-                                ["name": "R2-D2"],
+                            [
+                                "name": "Han Solo",
+                                "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
+                                "friends": [
+                                    ["name": "Luke Skywalker"],
+                                    ["name": "Leia Organa"],
+                                    ["name": "R2-D2"],
+                                ],
+                            ],
+                            [
+                                "name": "Leia Organa",
+                                "appearsIn": ["NEWHOPE", "EMPIRE", "JEDI"],
+                                "friends": [
+                                    ["name": "Luke Skywalker"],
+                                    ["name": "Han Solo"],
+                                    ["name": "C-3PO"],
+                                    ["name": "R2-D2"],
+                                ],
                             ],
                         ],
                     ],
-                ],
-            ]
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testFetchLukeQuery() throws {
-        let query = """
-        query FetchLukeQuery {
-            human(id: "1000") {
-                name
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "human": [
-                    "name": "Luke Skywalker",
-                ],
-            ]
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query FetchLukeQuery {
+                    human(id: "1000") {
+                        name
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "human": [
+                        "name": "Luke Skywalker",
+                    ],
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testFetchSomeIDQuery() throws {
-        let query = """
-        query FetchSomeIDQuery($someId: String!) {
-            human(id: $someId) {
-                name
-            }
-        }
-        """
-
-        var params: [String: Map]
-        var expected: GraphQLResult
-        var expectation: XCTestExpectation
-
-        params = ["someId": "1000"]
-
-        expected = GraphQLResult(
-            data: [
-                "human": [
-                    "name": "Luke Skywalker",
-                ],
-            ]
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query FetchSomeIDQuery($someId: String!) {
+                    human(id: $someId) {
+                        name
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group,
+                variables: ["someId": "1000"]
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "human": [
+                        "name": "Luke Skywalker",
+                    ],
+                ]
+            )
         )
 
-        expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group,
-            variables: params
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-
-        params = ["someId": "1002"]
-
-        expected = GraphQLResult(
-            data: [
-                "human": [
-                    "name": "Han Solo",
-                ],
-            ]
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query FetchSomeIDQuery($someId: String!) {
+                    human(id: $someId) {
+                        name
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group,
+                variables: ["someId": "1002"]
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "human": [
+                        "name": "Han Solo",
+                    ],
+                ]
+            )
         )
 
-        expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group,
-            variables: params
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-
-        params = ["someId": "not a valid id"]
-
-        expected = GraphQLResult(
-            data: [
-                "human": nil,
-            ]
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query FetchSomeIDQuery($someId: String!) {
+                    human(id: $someId) {
+                        name
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group,
+                variables: ["someId": "not a valid id"]
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "human": nil,
+                ]
+            )
         )
-
-        expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group,
-            variables: params
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testFetchLukeAliasedQuery() throws {
-        let query = """
-        query FetchLukeAliasedQuery {
-            luke: human(id: "1000") {
-                name
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "luke": [
-                    "name": "Luke Skywalker",
-                ],
-            ]
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query FetchLukeAliasedQuery {
+                    luke: human(id: "1000") {
+                        name
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "luke": [
+                        "name": "Luke Skywalker",
+                    ],
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testFetchLukeAndLeiaAliasedQuery() throws {
-        let query = """
-        query FetchLukeAndLeiaAliasedQuery {
-            luke: human(id: "1000") {
-                name
-            }
-            leia: human(id: "1003") {
-                name
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "luke": [
-                    "name": "Luke Skywalker",
-                ],
-                "leia": [
-                    "name": "Leia Organa",
-                ],
-            ]
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query FetchLukeAndLeiaAliasedQuery {
+                    luke: human(id: "1000") {
+                        name
+                    }
+                    leia: human(id: "1003") {
+                        name
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "luke": [
+                        "name": "Luke Skywalker",
+                    ],
+                    "leia": [
+                        "name": "Leia Organa",
+                    ],
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testDuplicateFieldsQuery() throws {
-        let query = """
-        query DuplicateFieldsQuery {
-            luke: human(id: "1000") {
-                name
-                homePlanet { name }
-            }
-            leia: human(id: "1003") {
-                name
-                homePlanet  { name }
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "luke": [
-                    "name": "Luke Skywalker",
-                    "homePlanet": ["name": "Tatooine"],
-                ],
-                "leia": [
-                    "name": "Leia Organa",
-                    "homePlanet": ["name": "Alderaan"],
-                ],
-            ]
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query DuplicateFieldsQuery {
+                    luke: human(id: "1000") {
+                        name
+                        homePlanet { name }
+                    }
+                    leia: human(id: "1003") {
+                        name
+                        homePlanet  { name }
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "luke": [
+                        "name": "Luke Skywalker",
+                        "homePlanet": ["name": "Tatooine"],
+                    ],
+                    "leia": [
+                        "name": "Leia Organa",
+                        "homePlanet": ["name": "Alderaan"],
+                    ],
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testUseFragmentQuery() throws {
-        let query = """
-        query UseFragmentQuery {
-            luke: human(id: "1000") {
-                ...HumanFragment
-            }
-            leia: human(id: "1003") {
-                ...HumanFragment
-            }
-        }
-        fragment HumanFragment on Human {
-            name
-            homePlanet { name }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "luke": [
-                    "name": "Luke Skywalker",
-                    "homePlanet": ["name": "Tatooine"],
-                ],
-                "leia": [
-                    "name": "Leia Organa",
-                    "homePlanet": ["name": "Alderaan"],
-                ],
-            ]
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query UseFragmentQuery {
+                    luke: human(id: "1000") {
+                        ...HumanFragment
+                    }
+                    leia: human(id: "1003") {
+                        ...HumanFragment
+                    }
+                }
+                fragment HumanFragment on Human {
+                    name
+                    homePlanet { name }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "luke": [
+                        "name": "Luke Skywalker",
+                        "homePlanet": ["name": "Tatooine"],
+                    ],
+                    "leia": [
+                        "name": "Leia Organa",
+                        "homePlanet": ["name": "Alderaan"],
+                    ],
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testCheckTypeOfR2Query() throws {
-        let query = """
-        query CheckTypeOfR2Query {
-            hero {
-                __typename
-                name
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "hero": [
-                    "__typename": "Droid",
-                    "name": "R2-D2",
-                ],
-            ]
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query CheckTypeOfR2Query {
+                    hero {
+                        __typename
+                        name
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "hero": [
+                        "__typename": "Droid",
+                        "name": "R2-D2",
+                    ],
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testCheckTypeOfLukeQuery() throws {
-        let query = """
-        query CheckTypeOfLukeQuery {
-            hero(episode: EMPIRE) {
-                __typename
-                name
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "hero": [
-                    "__typename": "Human",
-                    "name": "Luke Skywalker",
-                ],
-            ]
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query CheckTypeOfLukeQuery {
+                    hero(episode: EMPIRE) {
+                        __typename
+                        name
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "hero": [
+                        "__typename": "Human",
+                        "name": "Luke Skywalker",
+                    ],
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testSecretBackstoryQuery() throws {
-        let query = """
-        query SecretBackstoryQuery {
-            hero {
-                name
-                secretBackstory
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "hero": [
-                    "name": "R2-D2",
-                    "secretBackstory": nil,
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query SecretBackstoryQuery {
+                    hero {
+                        name
+                        secretBackstory
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "hero": [
+                        "name": "R2-D2",
+                        "secretBackstory": nil,
+                    ],
                 ],
-            ],
-            errors: [
-                GraphQLError(
-                    message: "secretBackstory is secret.",
-                    locations: [SourceLocation(line: 4, column: 9)],
-                    path: ["hero", "secretBackstory"]
-                ),
-            ]
+                errors: [
+                    GraphQLError(
+                        message: "secretBackstory is secret.",
+                        locations: [SourceLocation(line: 4, column: 9)],
+                        path: ["hero", "secretBackstory"]
+                    ),
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testSecretBackstoryListQuery() throws {
-        let query = """
-        query SecretBackstoryListQuery {
-            hero {
-                name
-                friends {
-                    name
-                    secretBackstory
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query SecretBackstoryListQuery {
+                    hero {
+                        name
+                        friends {
+                            name
+                            secretBackstory
+                        }
+                    }
                 }
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "hero": [
-                    "name": "R2-D2",
-                    "friends": [
-                        [
-                            "name": "Luke Skywalker",
-                            "secretBackstory": nil,
-                        ],
-                        [
-                            "name": "Han Solo",
-                            "secretBackstory": nil,
-                        ],
-                        [
-                            "name": "Leia Organa",
-                            "secretBackstory": nil,
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "hero": [
+                        "name": "R2-D2",
+                        "friends": [
+                            [
+                                "name": "Luke Skywalker",
+                                "secretBackstory": nil,
+                            ],
+                            [
+                                "name": "Han Solo",
+                                "secretBackstory": nil,
+                            ],
+                            [
+                                "name": "Leia Organa",
+                                "secretBackstory": nil,
+                            ],
                         ],
                     ],
                 ],
-            ],
-            errors: [
-                GraphQLError(
-                    message: "secretBackstory is secret.",
-                    locations: [SourceLocation(line: 6, column: 13)],
-                    path: ["hero", "friends", 0, "secretBackstory"]
-                ),
-                GraphQLError(
-                    message: "secretBackstory is secret.",
-                    locations: [SourceLocation(line: 6, column: 13)],
-                    path: ["hero", "friends", 1, "secretBackstory"]
-                ),
-                GraphQLError(
-                    message: "secretBackstory is secret.",
-                    locations: [SourceLocation(line: 6, column: 13)],
-                    path: ["hero", "friends", 2, "secretBackstory"]
-                ),
-            ]
+                errors: [
+                    GraphQLError(
+                        message: "secretBackstory is secret.",
+                        locations: [SourceLocation(line: 6, column: 13)],
+                        path: ["hero", "friends", 0, "secretBackstory"]
+                    ),
+                    GraphQLError(
+                        message: "secretBackstory is secret.",
+                        locations: [SourceLocation(line: 6, column: 13)],
+                        path: ["hero", "friends", 1, "secretBackstory"]
+                    ),
+                    GraphQLError(
+                        message: "secretBackstory is secret.",
+                        locations: [SourceLocation(line: 6, column: 13)],
+                        path: ["hero", "friends", 2, "secretBackstory"]
+                    ),
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testSecretBackstoryAliasQuery() throws {
-        let query = """
-        query SecretBackstoryAliasQuery {
-            mainHero: hero {
-                name
-                story: secretBackstory
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "mainHero": [
-                    "name": "R2-D2",
-                    "story": nil,
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query SecretBackstoryAliasQuery {
+                    mainHero: hero {
+                        name
+                        story: secretBackstory
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "mainHero": [
+                        "name": "R2-D2",
+                        "story": nil,
+                    ],
                 ],
-            ],
-            errors: [
-                GraphQLError(
-                    message: "secretBackstory is secret.",
-                    locations: [SourceLocation(line: 4, column: 9)],
-                    path: ["mainHero", "story"]
-                ),
-            ]
+                errors: [
+                    GraphQLError(
+                        message: "secretBackstory is secret.",
+                        locations: [SourceLocation(line: 4, column: 9)],
+                        path: ["mainHero", "story"]
+                    ),
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testNonNullableFieldsQuery() throws {
@@ -664,192 +543,133 @@ class StarWarsQueryTests: XCTestCase {
                 }
             }
         }
+        let api = MyAPI()
 
-        let query = """
-        query {
-            nullableA {
-                nullableA {
-                    nonNullA {
-                        nonNullA {
-                            throws
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query {
+                    nullableA {
+                        nullableA {
+                            nonNullA {
+                                nonNullA {
+                                    throws
+                                }
+                            }
                         }
                     }
                 }
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "nullableA": [
-                    "nullableA": nil,
+                """,
+                context: NoContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "nullableA": [
+                        "nullableA": nil,
+                    ],
                 ],
-            ],
-            errors: [
-                GraphQLError(
-                    message: "catch me if you can.",
-                    locations: [SourceLocation(line: 6, column: 21)],
-                    path: ["nullableA", "nullableA", "nonNullA", "nonNullA", "throws"]
-                ),
-            ]
+                errors: [
+                    GraphQLError(
+                        message: "catch me if you can.",
+                        locations: [SourceLocation(line: 6, column: 21)],
+                        path: ["nullableA", "nullableA", "nonNullA", "nonNullA", "throws"]
+                    ),
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-        let api = MyAPI()
-
-        api.execute(
-            request: query,
-            context: NoContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testSearchQuery() throws {
-        let query = """
-        query {
-            search(query: "o") {
-                ... on Planet {
-                    name
-                    diameter
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query {
+                    search(query: "o") {
+                        ... on Planet {
+                            name
+                            diameter
+                        }
+                        ... on Human {
+                            name
+                        }
+                        ... on Droid {
+                            name
+                            primaryFunction
+                        }
+                    }
                 }
-                ... on Human {
-                    name
-                }
-                ... on Droid {
-                    name
-                    primaryFunction
-                }
-            }
-        }
-        """
-
-        let expected = GraphQLResult(
-            data: [
-                "search": [
-                    ["name": "Tatooine", "diameter": 10465],
-                    ["name": "Han Solo"],
-                    ["name": "Leia Organa"],
-                    ["name": "C-3PO", "primaryFunction": "Protocol"],
-                ],
-            ]
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "search": [
+                        ["name": "Tatooine", "diameter": 10465],
+                        ["name": "Han Solo"],
+                        ["name": "Leia Organa"],
+                        ["name": "C-3PO", "primaryFunction": "Protocol"],
+                    ],
+                ]
+            )
         )
-
-        let expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
     }
 
     func testDirective() throws {
-        var query: String
-        var expected: GraphQLResult
-        var expectation: XCTestExpectation
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query Hero {
+                    hero {
+                        name
 
-        query = """
-        query Hero {
-            hero {
-                name
-
-                friends @include(if: false) {
-                    name
+                        friends @include(if: false) {
+                            name
+                        }
+                    }
                 }
-            }
-        }
-        """
-
-        expected = GraphQLResult(
-            data: [
-                "hero": [
-                    "name": "R2-D2",
-                ],
-            ]
-        )
-
-        expectation = XCTestExpectation()
-
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-
-        query = """
-        query Hero {
-            hero {
-                name
-
-                friends @include(if: true) {
-                    name
-                }
-            }
-        }
-        """
-
-        expected = GraphQLResult(
-            data: [
-                "hero": [
-                    "name": "R2-D2",
-                    "friends": [
-                        ["name": "Luke Skywalker"],
-                        ["name": "Han Solo"],
-                        ["name": "Leia Organa"],
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "hero": [
+                        "name": "R2-D2",
                     ],
-                ],
-            ]
+                ]
+            )
         )
 
-        expectation = XCTestExpectation()
+        XCTAssertEqual(
+            try api.execute(
+                request: """
+                query Hero {
+                    hero {
+                        name
 
-        api.execute(
-            request: query,
-            context: StarWarsContext(),
-            on: group
-        ).whenSuccess { result in
-            XCTAssertEqual(result, expected)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 10)
-    }
-}
-
-extension StarWarsQueryTests {
-    static var allTests: [(String, (StarWarsQueryTests) -> () throws -> Void)] {
-        return [
-            ("testHeroNameQuery", testHeroNameQuery),
-            ("testHeroNameAndFriendsQuery", testHeroNameAndFriendsQuery),
-            ("testNestedQuery", testNestedQuery),
-            ("testFetchLukeQuery", testFetchLukeQuery),
-            ("testFetchSomeIDQuery", testFetchSomeIDQuery),
-            ("testFetchLukeAliasedQuery", testFetchLukeAliasedQuery),
-            ("testFetchLukeAndLeiaAliasedQuery", testFetchLukeAndLeiaAliasedQuery),
-            ("testDuplicateFieldsQuery", testDuplicateFieldsQuery),
-            ("testUseFragmentQuery", testUseFragmentQuery),
-            ("testCheckTypeOfR2Query", testCheckTypeOfR2Query),
-            ("testCheckTypeOfLukeQuery", testCheckTypeOfLukeQuery),
-            ("testSecretBackstoryQuery", testSecretBackstoryQuery),
-            ("testSecretBackstoryListQuery", testSecretBackstoryListQuery),
-            ("testNonNullableFieldsQuery", testNonNullableFieldsQuery),
-            ("testSearchQuery", testSearchQuery),
-            ("testDirective", testDirective),
-        ]
+                        friends @include(if: true) {
+                            name
+                        }
+                    }
+                }
+                """,
+                context: StarWarsContext(),
+                on: group
+            ).wait(),
+            GraphQLResult(
+                data: [
+                    "hero": [
+                        "name": "R2-D2",
+                        "friends": [
+                            ["name": "Luke Skywalker"],
+                            ["name": "Han Solo"],
+                            ["name": "Leia Organa"],
+                        ],
+                    ],
+                ]
+            )
+        )
     }
 }


### PR DESCRIPTION
We were getting a few of the following warning in the test code:

```
warning: 'expectation' mutated after capture by sendable closure
```

This resolves the warnings by removing unnecessary use of `expectation` in the unit tests, replacing them with `try Future.wait()`. I took this opportunity to refactor these tests to simplify them to atomic XCTAssertEquals calls. I also removed the unused `allTests` extensions.

There were no functional changes to the tests themselves.