### PR TITLE
Breaking: Uses Swift Concurrency

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,30 @@
 # Migration
 
+## 2.0 to 3.0
+
+### NIO removal
+
+All NIO-based parameters and return types were removed, including all that used `EventLoopGroup` and `EventLoopFuture`s.
+
+As such, all `API.execute` and `API.subscribe` calls should have the `eventLoopGroup` argument removed, and the `await` keyword should be used. If access to an `eventLoopGroup` is required in the resolver, one should be passed via the `Context`.
+
+Also, all resolver closures have had the `eventLoopGroup` parameter removed, and all that return an `EventLoopFuture` should be converted to an `async` function.
+
+The documentation here may be very helpful in the conversion: https://www.swift.org/documentation/server/guides/libraries/concurrency-adoption-guidelines.html
+
+### Swift Concurrency checking
+
+With the conversion from NIO to Swift Concurrency, types used across async boundaries should conform to `Sendable` to avoid errors and warnings. This includes the Swift types and functions that back the GraphQL schema, including the `Resolver` and `Context` types. For more details on the conversion, see the [Sendable documentation](https://developer.apple.com/documentation/swift/sendable).
+
+### Subscription result changes
+
+The `API.subscribe(...)` will return a `Result<AsyncThrowingStream<GraphQLResult, Error>>`, instead of an `EventStream`. This means extracting the stream via a `.stream` call and downcasting to `ConcurrentEventStream` are no longer necessary.
+The `EventStream` and `SubscriptionResult` types have been removed.
+
+### GraphQL v4 upgrades
+
+See [the GraphQL v4 migration documentation](https://github.com/GraphQLSwift/GraphQL/blob/main/MIGRATION.md#3-to-4) for additional details.
+
 ## 1.0 to 2.0
 
 ### TypeReference removal

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,17 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GraphQLSwift/GraphQL.git",
       "state" : {
-        "revision" : "5e098b3b1789169dded5116c171f716d584225ea",
-        "version" : "3.0.0"
-      }
-    },
-    {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
-        "version" : "1.2.0"
+        "revision" : "eedec2bbfcfd0c10c2eaee8ac2f91bde5af28b8c",
+        "version" : "4.0.0"
       }
     },
     {
@@ -23,26 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
-        "version" : "1.1.4"
-      }
-    },
-    {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "f7dc3f527576c398709b017584392fb58592e7f5",
-        "version" : "2.75.0"
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
-        "version" : "1.4.0"
+        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
+        "version" : "1.2.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,5 +15,6 @@ let package = Package(
         .testTarget(name: "GraphitiTests", dependencies: ["Graphiti"], resources: [
             .copy("FederationTests/GraphQL"),
         ]),
-    ]
+    ],
+    swiftLanguageVersions: [.v5, .version("6")]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,12 @@ import PackageDescription
 
 let package = Package(
     name: "Graphiti",
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
     products: [
         .library(name: "Graphiti", targets: ["Graphiti"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "3.0.0"),
+        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "4.0.0"),
     ],
     targets: [
         .target(name: "Graphiti", dependencies: ["GraphQL"]),

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Graphiti 
+# Graphiti
 
 Graphiti is a Swift library for building GraphQL schemas fast, safely and easily.
 
@@ -86,7 +86,7 @@ struct MessageAPI : API {
     let resolver: Resolver
     let schema: Schema<Resolver, Context>
 }
-        
+
 let api = MessageAPI(
     resolver: Resolver()
     schema: try! Schema<Resolver, Context> {
@@ -124,7 +124,7 @@ let api = MessageAPI(
     resolver: Resolver()
     schema: schema
 )
-``` 
+```
 
 </details>
 <details>
@@ -136,7 +136,7 @@ final class ChatSchema: PartialSchema<Resolver, Context> {
     public override var types: Types {
         Type(Message.self) {
             Field("content", at: \.content)
-        }        
+        }
     }
 
     @FieldDefinitions
@@ -152,7 +152,7 @@ let api = MessageAPI(
     resolver: Resolver()
     schema: schema
 )
-``` 
+```
 
 </details>
 
@@ -164,7 +164,7 @@ let chatSchema = PartialSchema<Resolver, Context>(
     types:  {
         Type(Message.self) {
             Field("content", at: \.content)
-        }        
+        }
     },
     query: {
         Field("message", at: Resolver.message)
@@ -178,7 +178,7 @@ let api = MessageAPI(
     resolver: Resolver()
     schema: schema
 )
-``` 
+```
 
 </details>
 
@@ -190,20 +190,10 @@ let api = MessageAPI(
 
 #### Querying
 
-To query the schema we need to pass in a NIO EventLoopGroup to feed the execute function alongside the query itself.
-
 ```swift
-import NIO
-
-let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-defer {
-    try? group.syncShutdownGracefully()
-}
-
 let result = try await api.execute(
     request: "{ message { content } }",
-    context: Context(),
-    on: group
+    context: Context()
 )
 print(result)
 ```
@@ -228,27 +218,13 @@ struct Resolver {
 }
 ```
 
-#### NIO resolvers
-
-The resolver functions also support `NIO`-style concurrency. To do so, just add one more parameter with type `EventLoopGroup` to the resolver function and change the return type to `EventLoopFuture<YouReturnType>`. Don't forget to import NIO.
-
-```swift
-import NIO
-
-struct Resolver {
-    func message(context: Context, arguments: NoArguments, group: EventLoopGroup) -> EventLoopFuture<Message> {
-        group.next().makeSucceededFuture(context.message())
-    }
-}
-```
-
 #### Subscription
 
 This library supports GraphQL subscriptions, and supports them through the Swift Concurrency `AsyncThrowingStream` type. See the [Usage Guide](UsageGuide.md#subscriptions) for details.
 
 If you are unable to use Swift Concurrency, you must create a concrete subclass of the `EventStream` class that implements event streaming
 functionality. If you don't feel like creating a subclass yourself, you can use the [GraphQLRxSwift](https://github.com/GraphQLSwift/GraphQLRxSwift) repository
-to integrate [RxSwift](https://github.com/ReactiveX/RxSwift) observables out-of-the-box. Or you can use that repository as a reference to connect a different 
+to integrate [RxSwift](https://github.com/ReactiveX/RxSwift) observables out-of-the-box. Or you can use that repository as a reference to connect a different
 stream library like [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift), [OpenCombine](https://github.com/OpenCombine/OpenCombine), or
 one that you've created yourself.
 

--- a/Sources/Graphiti/API/API.swift
+++ b/Sources/Graphiti/API/API.swift
@@ -1,5 +1,4 @@
 import GraphQL
-import NIO
 
 public protocol API {
     associatedtype Resolver
@@ -12,143 +11,59 @@ public extension API {
     func execute(
         request: String,
         context: ContextType,
-        on eventLoopGroup: EventLoopGroup,
         variables: [String: Map] = [:],
         operationName: String? = nil,
-        validationRules: [(ValidationContext) -> Visitor] = []
-    ) -> EventLoopFuture<GraphQLResult> {
-        return schema.execute(
-            request: request,
-            resolver: resolver,
-            context: context,
-            eventLoopGroup: eventLoopGroup,
-            variables: variables,
-            operationName: operationName,
-            validationRules: validationRules
-        )
-    }
-
-    func execute(
-        request: GraphQLRequest,
-        context: ContextType,
-        on eventLoopGroup: EventLoopGroup,
-        validationRules: [(ValidationContext) -> Visitor] = []
-    ) -> EventLoopFuture<GraphQLResult> {
-        return execute(
-            request: request.query,
-            context: context,
-            on: eventLoopGroup,
-            variables: request.variables,
-            operationName: request.operationName,
-            validationRules: validationRules
-        )
-    }
-
-    func subscribe(
-        request: String,
-        context: ContextType,
-        on eventLoopGroup: EventLoopGroup,
-        variables: [String: Map] = [:],
-        operationName: String? = nil,
-        validationRules: [(ValidationContext) -> Visitor] = []
-    ) -> EventLoopFuture<SubscriptionResult> {
-        return schema.subscribe(
-            request: request,
-            resolver: resolver,
-            context: context,
-            eventLoopGroup: eventLoopGroup,
-            variables: variables,
-            operationName: operationName,
-            validationRules: validationRules
-        )
-    }
-
-    func subscribe(
-        request: GraphQLRequest,
-        context: ContextType,
-        on eventLoopGroup: EventLoopGroup,
-        validationRules: [(ValidationContext) -> Visitor] = []
-    ) -> EventLoopFuture<SubscriptionResult> {
-        return subscribe(
-            request: request.query,
-            context: context,
-            on: eventLoopGroup,
-            variables: request.variables,
-            operationName: request.operationName,
-            validationRules: validationRules
-        )
-    }
-}
-
-public extension API {
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
-    func execute(
-        request: String,
-        context: ContextType,
-        on eventLoopGroup: EventLoopGroup,
-        variables: [String: Map] = [:],
-        operationName: String? = nil,
-        validationRules: [(ValidationContext) -> Visitor] = []
+        validationRules: [@Sendable (ValidationContext) -> Visitor] = []
     ) async throws -> GraphQLResult {
         return try await schema.execute(
             request: request,
             resolver: resolver,
             context: context,
-            eventLoopGroup: eventLoopGroup,
             variables: variables,
             operationName: operationName,
             validationRules: validationRules
-        ).get()
+        )
     }
 
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
     func execute(
         request: GraphQLRequest,
         context: ContextType,
-        on eventLoopGroup: EventLoopGroup,
-        validationRules: [(ValidationContext) -> Visitor] = []
+        validationRules: [@Sendable (ValidationContext) -> Visitor] = []
     ) async throws -> GraphQLResult {
         return try await execute(
             request: request.query,
             context: context,
-            on: eventLoopGroup,
             variables: request.variables,
             operationName: request.operationName,
             validationRules: validationRules
         )
     }
 
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
     func subscribe(
         request: String,
         context: ContextType,
-        on eventLoopGroup: EventLoopGroup,
         variables: [String: Map] = [:],
         operationName: String? = nil,
-        validationRules: [(ValidationContext) -> Visitor] = []
-    ) async throws -> SubscriptionResult {
+        validationRules: [@Sendable (ValidationContext) -> Visitor] = []
+    ) async throws -> Result<AsyncThrowingStream<GraphQLResult, Error>, GraphQLErrors> {
         return try await schema.subscribe(
             request: request,
             resolver: resolver,
             context: context,
-            eventLoopGroup: eventLoopGroup,
             variables: variables,
             operationName: operationName,
             validationRules: validationRules
-        ).get()
+        )
     }
 
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
     func subscribe(
         request: GraphQLRequest,
         context: ContextType,
-        on eventLoopGroup: EventLoopGroup,
-        validationRules: [(ValidationContext) -> Visitor] = []
-    ) async throws -> SubscriptionResult {
+        validationRules: [@Sendable (ValidationContext) -> Visitor] = []
+    ) async throws -> Result<AsyncThrowingStream<GraphQLResult, Error>, GraphQLErrors> {
         return try await subscribe(
             request: request.query,
             context: context,
-            on: eventLoopGroup,
             variables: request.variables,
             operationName: request.operationName,
             validationRules: validationRules

--- a/Sources/Graphiti/API/API.swift
+++ b/Sources/Graphiti/API/API.swift
@@ -1,8 +1,8 @@
 import GraphQL
 
 public protocol API {
-    associatedtype Resolver
-    associatedtype ContextType
+    associatedtype Resolver: Sendable
+    associatedtype ContextType: Sendable
     var resolver: Resolver { get }
     var schema: Schema<Resolver, ContextType> { get }
 }

--- a/Sources/Graphiti/Argument/Argument.swift
+++ b/Sources/Graphiti/Argument/Argument.swift
@@ -2,7 +2,7 @@ import GraphQL
 
 public class Argument<ArgumentsType: Decodable, ArgumentType>: ArgumentComponent<ArgumentsType> {
     let name: String
-    var defaultValue: AnyEncodable? = nil
+    var defaultValue: AnyEncodable?
 
     override func argument(
         typeProvider: TypeProvider,

--- a/Sources/Graphiti/Argument/ArgumentComponent.swift
+++ b/Sources/Graphiti/Argument/ArgumentComponent.swift
@@ -1,7 +1,7 @@
 import GraphQL
 
 public class ArgumentComponent<ArgumentsType: Decodable> {
-    var description: String? = nil
+    var description: String?
 
     func argument(
         typeProvider _: TypeProvider,

--- a/Sources/Graphiti/Argument/NoArguments.swift
+++ b/Sources/Graphiti/Argument/NoArguments.swift
@@ -1,3 +1,3 @@
-public struct NoArguments: Decodable {
+public struct NoArguments: Decodable, Sendable {
     public init() {}
 }

--- a/Sources/Graphiti/Coder/Coders.swift
+++ b/Sources/Graphiti/Coder/Coders.swift
@@ -3,7 +3,7 @@ import GraphQL
 
 /// Struct containing a MapEncoder and MapDecoder. These decoders are passed through to the Schema objects and used in
 /// all encoding and decoding from maps.
-public struct Coders {
+public struct Coders: Sendable {
     public let decoder = MapDecoder()
     public let encoder = MapEncoder()
 

--- a/Sources/Graphiti/Component/Component.swift
+++ b/Sources/Graphiti/Component/Component.swift
@@ -1,6 +1,6 @@
 import GraphQL
 
-open class Component<Resolver, Context> {
+open class Component<Resolver: Sendable, Context: Sendable> {
     let name: String
     var description: String?
     var componentType: ComponentType

--- a/Sources/Graphiti/Connection/Connection.swift
+++ b/Sources/Graphiti/Connection/Connection.swift
@@ -1,13 +1,11 @@
 import Foundation
 import GraphQL
-import NIO
 
 public struct Connection<Node> {
     public let edges: [Edge<Node>]
     public let pageInfo: PageInfo
 }
 
-@available(macOS 10.15, macCatalyst 13.0, iOS 13.0, tvOS 13, watchOS 6.0, *) // For Identifiable
 public extension Connection where Node: Identifiable, Node.ID: LosslessStringConvertible {
     static func id(_ cursor: String) -> Node.ID? {
         cursor.base64Decoded().flatMap { Node.ID($0) }
@@ -18,54 +16,6 @@ public extension Connection where Node: Identifiable, Node.ID: LosslessStringCon
     }
 }
 
-@available(macOS 10.15, macCatalyst 13.0, iOS 13.0, tvOS 13, watchOS 6.0, *) // For Identifiable
-public extension EventLoopFuture where Value: Sequence, Value.Element: Identifiable,
-Value.Element.ID: LosslessStringConvertible {
-    func connection(from arguments: Paginatable) -> EventLoopFuture<Connection<Value.Element>> {
-        connection(from: arguments, makeCursor: Connection<Value.Element>.cursor)
-    }
-
-    func connection(from arguments: ForwardPaginatable)
-    -> EventLoopFuture<Connection<Value.Element>> {
-        connection(from: arguments, makeCursor: Connection<Value.Element>.cursor)
-    }
-
-    func connection(from arguments: BackwardPaginatable)
-    -> EventLoopFuture<Connection<Value.Element>> {
-        connection(from: arguments, makeCursor: Connection<Value.Element>.cursor)
-    }
-}
-
-public extension EventLoopFuture where Value: Sequence {
-    func connection(
-        from arguments: Paginatable,
-        makeCursor: @escaping (Value.Element) throws -> String
-    ) -> EventLoopFuture<Connection<Value.Element>> {
-        flatMapThrowing { value in
-            try value.connection(from: arguments, makeCursor: makeCursor)
-        }
-    }
-
-    func connection(
-        from arguments: ForwardPaginatable,
-        makeCursor: @escaping (Value.Element) throws -> String
-    ) -> EventLoopFuture<Connection<Value.Element>> {
-        flatMapThrowing { value in
-            try value.connection(from: arguments, makeCursor: makeCursor)
-        }
-    }
-
-    func connection(
-        from arguments: BackwardPaginatable,
-        makeCursor: @escaping (Value.Element) throws -> String
-    ) -> EventLoopFuture<Connection<Value.Element>> {
-        flatMapThrowing { value in
-            try value.connection(from: arguments, makeCursor: makeCursor)
-        }
-    }
-}
-
-@available(macOS 10.15, macCatalyst 13.0, iOS 13.0, tvOS 13, watchOS 6.0, *) // For Identifiable
 public extension Sequence where Element: Identifiable,
 Element.ID: LosslessStringConvertible {
     func connection(from arguments: Paginatable) throws -> Connection<Element> {

--- a/Sources/Graphiti/Connection/Connection.swift
+++ b/Sources/Graphiti/Connection/Connection.swift
@@ -1,7 +1,7 @@
 import Foundation
 import GraphQL
 
-public struct Connection<Node> {
+public struct Connection<Node: Sendable>: Sendable {
     public let edges: [Edge<Node>]
     public let pageInfo: PageInfo
 }
@@ -16,7 +16,7 @@ public extension Connection where Node: Identifiable, Node.ID: LosslessStringCon
     }
 }
 
-public extension Sequence where Element: Identifiable,
+public extension Sequence where Element: Sendable, Element: Identifiable,
 Element.ID: LosslessStringConvertible {
     func connection(from arguments: Paginatable) throws -> Connection<Element> {
         try connection(from: arguments, makeCursor: Connection<Element>.cursor)
@@ -31,7 +31,7 @@ Element.ID: LosslessStringConvertible {
     }
 }
 
-public extension Sequence {
+public extension Sequence where Element: Sendable {
     func connection(
         from arguments: Paginatable,
         makeCursor: @escaping (Element) throws -> String

--- a/Sources/Graphiti/Connection/ConnectionType.swift
+++ b/Sources/Graphiti/Connection/ConnectionType.swift
@@ -1,9 +1,9 @@
 import GraphQL
 
 public final class ConnectionType<
-    Resolver,
-    Context,
-    ObjectType
+    Resolver: Sendable,
+    Context: Sendable,
+    ObjectType: Sendable
 >: TypeComponent<
     Resolver,
     Context

--- a/Sources/Graphiti/Connection/Edge.swift
+++ b/Sources/Graphiti/Connection/Edge.swift
@@ -1,10 +1,10 @@
-protocol Edgeable {
+protocol Edgeable: Sendable {
     associatedtype Node
     var node: Node { get }
     var cursor: String { get }
 }
 
-public struct Edge<Node>: Edgeable {
+public struct Edge<Node: Sendable>: Edgeable {
     public let node: Node
     public let cursor: String
 }

--- a/Sources/Graphiti/Connection/PageInfo.swift
+++ b/Sources/Graphiti/Connection/PageInfo.swift
@@ -1,4 +1,4 @@
-public struct PageInfo: Codable {
+public struct PageInfo: Codable, Sendable {
     public let hasPreviousPage: Bool
     public let hasNextPage: Bool
     public let startCursor: String?

--- a/Sources/Graphiti/Connection/PagniationArguments/PaginationArguments.swift
+++ b/Sources/Graphiti/Connection/PagniationArguments/PaginationArguments.swift
@@ -1,6 +1,6 @@
 public protocol Paginatable: ForwardPaginatable, BackwardPaginatable {}
 
-public struct PaginationArguments: Paginatable {
+public struct PaginationArguments: Paginatable, Sendable {
     public let first: Int?
     public let last: Int?
     public let after: String?

--- a/Sources/Graphiti/Enum/Enum.swift
+++ b/Sources/Graphiti/Enum/Enum.swift
@@ -1,8 +1,8 @@
 import GraphQL
 
 public final class Enum<
-    Resolver,
-    Context,
+    Resolver: Sendable,
+    Context: Sendable,
     EnumType: Encodable & RawRepresentable
 >: TypeComponent<
     Resolver,

--- a/Sources/Graphiti/Federation/Entity.swift
+++ b/Sources/Graphiti/Federation/Entity.swift
@@ -1,6 +1,5 @@
 import Foundation
 import GraphQL
-import NIO
 
 struct EntityArguments: Codable {
     let representations: [Map]

--- a/Sources/Graphiti/Federation/Key/Key.swift
+++ b/Sources/Graphiti/Federation/Key/Key.swift
@@ -1,10 +1,15 @@
 import GraphQL
 
-public class Key<ObjectType, Resolver, Context, Arguments: Codable>: KeyComponent<
+public class Key<
+    ObjectType: Sendable,
+    Resolver: Sendable,
+    Context: Sendable,
+    Arguments: Codable & Sendable
+>: KeyComponent<
     ObjectType,
     Resolver,
     Context
-> {
+>, @unchecked Sendable {
     let arguments: [ArgumentComponent<Arguments>]
     let resolve: AsyncResolve<Resolver, Context, Arguments, ObjectType?>
 
@@ -18,7 +23,7 @@ public class Key<ObjectType, Resolver, Context, Arguments: Codable>: KeyComponen
         context: Context,
         map: Map,
         coders: Coders
-    ) async throws -> Any? {
+    ) async throws -> (any Sendable)? {
         let arguments = try coders.decoder.decode(Arguments.self, from: map)
         return try await resolve(resolver)(context, arguments)
     }

--- a/Sources/Graphiti/Federation/Key/KeyComponent.swift
+++ b/Sources/Graphiti/Federation/Key/KeyComponent.swift
@@ -1,6 +1,6 @@
 import GraphQL
 
-public class KeyComponent<ObjectType, Resolver, Context> {
+public class KeyComponent<ObjectType, Resolver, Context>: @unchecked Sendable {
     func mapMatchesArguments(_: Map, coders _: Coders) -> Bool {
         fatalError()
     }
@@ -10,7 +10,7 @@ public class KeyComponent<ObjectType, Resolver, Context> {
         context _: Context,
         map _: Map,
         coders _: Coders
-    ) async throws -> Any? {
+    ) async throws -> (any Sendable)? {
         fatalError()
     }
 

--- a/Sources/Graphiti/Federation/Key/KeyComponent.swift
+++ b/Sources/Graphiti/Federation/Key/KeyComponent.swift
@@ -1,5 +1,4 @@
 import GraphQL
-import NIO
 
 public class KeyComponent<ObjectType, Resolver, Context> {
     func mapMatchesArguments(_: Map, coders _: Coders) -> Bool {
@@ -10,9 +9,8 @@ public class KeyComponent<ObjectType, Resolver, Context> {
         resolver _: Resolver,
         context _: Context,
         map _: Map,
-        eventLoopGroup _: EventLoopGroup,
         coders _: Coders
-    ) throws -> EventLoopFuture<Any?> {
+    ) async throws -> Any? {
         fatalError()
     }
 

--- a/Sources/Graphiti/Federation/Key/Type+Key.swift
+++ b/Sources/Graphiti/Federation/Key/Type+Key.swift
@@ -43,39 +43,6 @@ public extension Type {
     /// - Returns: Self for chaining.
     @discardableResult
     func key<Arguments: Codable>(
-        at function: @escaping SimpleAsyncResolve<Resolver, Context, Arguments, ObjectType?>,
-        @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
-    ) -> Self {
-        keys.append(Key(arguments: [argument()], simpleAsyncResolve: function))
-        return self
-    }
-
-    /// Define and add the federated key to this type.
-    ///
-    /// For more information, see https://www.apollographql.com/docs/federation/entities
-    /// - Parameters:
-    ///   - function: The resolver function used to load this entity based on the key value.
-    ///   - _:  The key values. The names of these arguments must match Type fields.
-    /// - Returns: Self for chaining.
-    @discardableResult
-    func key<Arguments: Codable>(
-        at function: @escaping SimpleAsyncResolve<Resolver, Context, Arguments, ObjectType?>,
-        @ArgumentComponentBuilder<Arguments> _ arguments: ()
-            -> [ArgumentComponent<Arguments>] = { [] }
-    ) -> Self {
-        keys.append(Key(arguments: arguments(), simpleAsyncResolve: function))
-        return self
-    }
-
-    /// Define and add the federated key to this type.
-    ///
-    /// For more information, see https://www.apollographql.com/docs/federation/entities
-    /// - Parameters:
-    ///   - function: The resolver function used to load this entity based on the key value.
-    ///   - _:  The key value. The name of this argument must match a Type field.
-    /// - Returns: Self for chaining.
-    @discardableResult
-    func key<Arguments: Codable>(
         at function: @escaping SyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
             -> [ArgumentComponent<Arguments>] = { [] }
@@ -97,42 +64,6 @@ public extension Type {
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) -> Self {
         keys.append(Key(arguments: [argument()], syncResolve: function))
-        return self
-    }
-}
-
-public extension Type {
-    /// Define and add the federated key to this type.
-    ///
-    /// For more information, see https://www.apollographql.com/docs/federation/entities
-    /// - Parameters:
-    ///   - function: The resolver function used to load this entity based on the key value.
-    ///   - _:  The key value. The name of this argument must match a Type field.
-    /// - Returns: Self for chaining.
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
-    @discardableResult
-    func key<Arguments: Codable>(
-        at function: @escaping ConcurrentResolve<Resolver, Context, Arguments, ObjectType?>,
-        @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
-    ) -> Self {
-        keys.append(Key(arguments: [argument()], concurrentResolve: function))
-        return self
-    }
-
-    /// Define and add the federated key to this type.
-    ///
-    /// For more information, see https://www.apollographql.com/docs/federation/entities
-    /// - Parameters:
-    ///   - function: The resolver function used to load this entity based on the key value.
-    ///   - _:  The key values. The names of these arguments must match Type fields.
-    /// - Returns: Self for chaining.
-    @available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
-    @discardableResult
-    func key<Arguments: Codable>(
-        at function: @escaping ConcurrentResolve<Resolver, Context, Arguments, ObjectType?>,
-        @ArgumentComponentBuilder<Arguments> _ arguments: () -> [ArgumentComponent<Arguments>]
-    ) -> Self {
-        keys.append(Key(arguments: arguments(), concurrentResolve: function))
         return self
     }
 }

--- a/Sources/Graphiti/Federation/Key/Type+Key.swift
+++ b/Sources/Graphiti/Federation/Key/Type+Key.swift
@@ -9,7 +9,7 @@ public extension Type {
     ///   - _:  The key value. The name of this argument must match a Type field.
     /// - Returns: Self for chaining.
     @discardableResult
-    func key<Arguments: Codable>(
+    func key<Arguments: Codable & Sendable>(
         at function: @escaping AsyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) -> Self {
@@ -25,7 +25,7 @@ public extension Type {
     ///   - _:  The key values. The names of these arguments must match Type fields.
     /// - Returns: Self for chaining.
     @discardableResult
-    func key<Arguments: Codable>(
+    func key<Arguments: Codable & Sendable>(
         at function: @escaping AsyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
             -> [ArgumentComponent<Arguments>] = { [] }
@@ -42,7 +42,7 @@ public extension Type {
     ///   - _:  The key value. The name of this argument must match a Type field.
     /// - Returns: Self for chaining.
     @discardableResult
-    func key<Arguments: Codable>(
+    func key<Arguments: Codable & Sendable>(
         at function: @escaping SyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
             -> [ArgumentComponent<Arguments>] = { [] }
@@ -59,7 +59,7 @@ public extension Type {
     ///   - _:  The key values. The names of these arguments must match Type fields.
     /// - Returns: Self for chaining.
     @discardableResult
-    func key<Arguments: Codable>(
+    func key<Arguments: Codable & Sendable>(
         at function: @escaping SyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) -> Self {

--- a/Sources/Graphiti/Federation/Queries.swift
+++ b/Sources/Graphiti/Federation/Queries.swift
@@ -26,8 +26,8 @@ func entitiesQuery(
         ],
         resolve: { source, args, context, info in
             let arguments = try coders.decoder.decode(EntityArguments.self, from: args)
-            return try await withThrowingTaskGroup(of: (Int, Any?).self) { group in
-                var results: [Any?] = arguments.representations.map { _ in nil }
+            return try await withThrowingTaskGroup(of: (Int, (any Sendable)?).self) { group in
+                var results: [(any Sendable)?] = arguments.representations.map { _ in nil }
                 for (index, representationMap) in arguments.representations.enumerated() {
                     group.addTask {
                         let representation = try coders.decoder.decode(

--- a/Sources/Graphiti/Federation/Queries.swift
+++ b/Sources/Graphiti/Federation/Queries.swift
@@ -20,7 +20,9 @@ func entitiesQuery(
         type: GraphQLNonNull(GraphQLList(entityType)),
         description: "Return all entities matching the provided representations.",
         args: [
-            "representations": GraphQLArgument(type: GraphQLNonNull(GraphQLList(GraphQLNonNull(anyType)))),
+            "representations": GraphQLArgument(
+                type: GraphQLNonNull(GraphQLList(GraphQLNonNull(anyType)))
+            ),
         ],
         resolve: { source, args, context, info in
             let arguments = try coders.decoder.decode(EntityArguments.self, from: args)

--- a/Sources/Graphiti/Federation/Queries.swift
+++ b/Sources/Graphiti/Federation/Queries.swift
@@ -1,13 +1,12 @@
 import GraphQL
-import NIO
 
 func serviceQuery(for sdl: String) -> GraphQLField {
     return GraphQLField(
         type: GraphQLNonNull(serviceType),
         description: "Return the SDL string for the subschema",
-        resolve: { _, _, _, eventLoopGroup, _ in
+        resolve: { _, _, _, _ in
             let result = Service(sdl: sdl)
-            return eventLoopGroup.any().makeSucceededFuture(result)
+            return result
         }
     )
 }
@@ -23,30 +22,35 @@ func entitiesQuery(
         args: [
             "representations": GraphQLArgument(type: GraphQLNonNull(GraphQLList(GraphQLNonNull(anyType)))),
         ],
-        resolve: { source, args, context, eventLoopGroup, info in
+        resolve: { source, args, context, info in
             let arguments = try coders.decoder.decode(EntityArguments.self, from: args)
-            let futures: [EventLoopFuture<Any?>] = try arguments.representations
-                .map { (representationMap: Map) in
-                    let representation = try coders.decoder.decode(
-                        EntityRepresentation.self,
-                        from: representationMap
-                    )
-                    guard let resolve = federatedResolvers[representation.__typename] else {
-                        throw GraphQLError(
-                            message: "Federated type not found: \(representation.__typename)"
+            return try await withThrowingTaskGroup(of: (Int, Any?).self) { group in
+                var results: [Any?] = arguments.representations.map { _ in nil }
+                for (index, representationMap) in arguments.representations.enumerated() {
+                    group.addTask {
+                        let representation = try coders.decoder.decode(
+                            EntityRepresentation.self,
+                            from: representationMap
                         )
+                        guard let resolve = federatedResolvers[representation.__typename] else {
+                            throw GraphQLError(
+                                message: "Federated type not found: \(representation.__typename)"
+                            )
+                        }
+                        let result = try await resolve(
+                            source,
+                            representationMap,
+                            context,
+                            info
+                        )
+                        return (index, result)
                     }
-                    return try resolve(
-                        source,
-                        representationMap,
-                        context,
-                        eventLoopGroup,
-                        info
-                    )
                 }
-
-            return futures.flatten(on: eventLoopGroup)
-                .map { $0 as Any? }
+                for try await result in group {
+                    results[result.0] = result.1
+                }
+                return results
+            }
         }
     )
 }

--- a/Sources/Graphiti/Field/Resolve/AsyncResolve.swift
+++ b/Sources/Graphiti/Field/Resolve/AsyncResolve.swift
@@ -1,9 +1,7 @@
-import NIO
 
-public typealias AsyncResolve<ObjectType, Context, Arguments, ResolveType> = (
+public typealias AsyncResolve<ObjectType, Context, Arguments, ResolveType> = @Sendable (
     _ object: ObjectType
 ) -> (
     _ context: Context,
-    _ arguments: Arguments,
-    _ eventLoopGroup: EventLoopGroup
-) throws -> EventLoopFuture<ResolveType>
+    _ arguments: Arguments
+) async throws -> ResolveType

--- a/Sources/Graphiti/Field/Resolve/ConcurrentResolve.swift
+++ b/Sources/Graphiti/Field/Resolve/ConcurrentResolve.swift
@@ -1,9 +1,0 @@
-import NIO
-
-@available(macOS 10.15, iOS 15, watchOS 8, tvOS 15, *)
-public typealias ConcurrentResolve<ObjectType, Context, Arguments, ResolveType> = (
-    _ object: ObjectType
-) -> (
-    _ context: Context,
-    _ arguments: Arguments
-) async throws -> ResolveType

--- a/Sources/Graphiti/Field/Resolve/SimpleAsyncResolve.swift
+++ b/Sources/Graphiti/Field/Resolve/SimpleAsyncResolve.swift
@@ -1,8 +1,0 @@
-import NIO
-
-public typealias SimpleAsyncResolve<ObjectType, Context, Arguments, ResolveType> = (
-    _ object: ObjectType
-) -> (
-    _ context: Context,
-    _ arguments: Arguments
-) throws -> EventLoopFuture<ResolveType>

--- a/Sources/Graphiti/Field/Resolve/SyncResolve.swift
+++ b/Sources/Graphiti/Field/Resolve/SyncResolve.swift
@@ -1,4 +1,4 @@
-public typealias SyncResolve<ObjectType, Context, Arguments, ResolveType> = (
+public typealias SyncResolve<ObjectType, Context, Arguments, ResolveType> = @Sendable (
     _ object: ObjectType
 ) -> (
     _ context: Context,

--- a/Sources/Graphiti/Input/Input.swift
+++ b/Sources/Graphiti/Input/Input.swift
@@ -1,8 +1,8 @@
 import GraphQL
 
 public final class Input<
-    Resolver,
-    Context,
+    Resolver: Sendable,
+    Context: Sendable,
     InputObjectType
 >: TypeComponent<
     Resolver,

--- a/Sources/Graphiti/InputField/InputField.swift
+++ b/Sources/Graphiti/InputField/InputField.swift
@@ -2,7 +2,7 @@ import GraphQL
 
 public class InputField<
     InputObjectType,
-    Context,
+    Context: Sendable,
     FieldType
 >: InputFieldComponent<
     InputObjectType,

--- a/Sources/Graphiti/Interface/Interface.swift
+++ b/Sources/Graphiti/Interface/Interface.swift
@@ -1,6 +1,10 @@
 import GraphQL
 
-public final class Interface<Resolver, Context, InterfaceType>: TypeComponent<
+public final class Interface<
+    Resolver: Sendable,
+    Context: Sendable,
+    InterfaceType
+>: TypeComponent<
     Resolver,
     Context
 > {

--- a/Sources/Graphiti/Mutation/Mutation.swift
+++ b/Sources/Graphiti/Mutation/Mutation.swift
@@ -1,6 +1,6 @@
 import GraphQL
 
-public final class Mutation<Resolver, Context>: Component<Resolver, Context> {
+public final class Mutation<Resolver: Sendable, Context: Sendable>: Component<Resolver, Context> {
     let fields: [FieldComponent<Resolver, Context>]
 
     let isTypeOf: GraphQLIsTypeOf = { source, _ in

--- a/Sources/Graphiti/Mutation/Mutation.swift
+++ b/Sources/Graphiti/Mutation/Mutation.swift
@@ -3,7 +3,7 @@ import GraphQL
 public final class Mutation<Resolver, Context>: Component<Resolver, Context> {
     let fields: [FieldComponent<Resolver, Context>]
 
-    let isTypeOf: GraphQLIsTypeOf = { source, _, _ in
+    let isTypeOf: GraphQLIsTypeOf = { source, _ in
         source is Resolver
     }
 

--- a/Sources/Graphiti/Query/Query.swift
+++ b/Sources/Graphiti/Query/Query.swift
@@ -3,7 +3,7 @@ import GraphQL
 public final class Query<Resolver, Context>: Component<Resolver, Context> {
     let fields: [FieldComponent<Resolver, Context>]
 
-    let isTypeOf: GraphQLIsTypeOf = { source, _, _ in
+    let isTypeOf: GraphQLIsTypeOf = { source, _ in
         source is Resolver
     }
 

--- a/Sources/Graphiti/Query/Query.swift
+++ b/Sources/Graphiti/Query/Query.swift
@@ -1,6 +1,6 @@
 import GraphQL
 
-public final class Query<Resolver, Context>: Component<Resolver, Context> {
+public final class Query<Resolver: Sendable, Context: Sendable>: Component<Resolver, Context> {
     let fields: [FieldComponent<Resolver, Context>]
 
     let isTypeOf: GraphQLIsTypeOf = { source, _ in

--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -4,7 +4,7 @@ public struct SchemaError: Error, Equatable {
     let description: String
 }
 
-public final class Schema<Resolver, Context> {
+public final class Schema<Resolver: Sendable, Context: Sendable> {
     public let schema: GraphQLSchema
 
     init(

--- a/Sources/Graphiti/Schema/SchemaTypeProvider.swift
+++ b/Sources/Graphiti/Schema/SchemaTypeProvider.swift
@@ -17,7 +17,7 @@ final class SchemaTypeProvider: TypeProvider {
 
     var federatedTypes: [GraphQLObjectType] = []
     var federatedResolvers: [String: GraphQLFieldResolve] = [:]
-    var federatedSDL: String? = nil
+    var federatedSDL: String?
 
     var query: GraphQLObjectType?
     var mutation: GraphQLObjectType?

--- a/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
+++ b/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
@@ -1,6 +1,6 @@
 /// A partial schema that declare a set of type, query, mutation, and/or subscription definition
 /// which can be compiled together into 1 schema.
-open class PartialSchema<Resolver, Context> {
+open class PartialSchema<Resolver: Sendable, Context: Sendable> {
     /// A custom parameter attribute that constructs type definitions from closures.
     public typealias TypeDefinitions = TypeComponentBuilder<Resolver, Context>
 

--- a/Sources/Graphiti/SchemaBuilders/SchemaBuilder.swift
+++ b/Sources/Graphiti/SchemaBuilders/SchemaBuilder.swift
@@ -1,6 +1,6 @@
 /// A builder that allows modular creation of GraphQL schemas. You may independently components or query, mutation, or subscription fields.
 /// When ready to build and use the schema, run `build`
-public final class SchemaBuilder<Resolver, Context> {
+public final class SchemaBuilder<Resolver: Sendable, Context: Sendable> {
     private var coders: Coders
     private var federatedSDL: String?
     private var typeComponents: [TypeComponent<Resolver, Context>]

--- a/Sources/Graphiti/Subscription/SubscribeResolve.swift
+++ b/Sources/Graphiti/Subscription/SubscribeResolve.swift
@@ -1,9 +1,7 @@
-import NIO
 
 public typealias SubscribeResolve<ObjectType, Context, Arguments, ResolveType> = (
     _ object: ObjectType
 ) -> (
     _ context: Context,
-    _ arguments: Arguments,
-    _ eventLoopGroup: EventLoopGroup
-) throws -> EventLoopFuture<ResolveType>
+    _ arguments: Arguments
+) async throws -> ResolveType

--- a/Sources/Graphiti/Subscription/Subscription.swift
+++ b/Sources/Graphiti/Subscription/Subscription.swift
@@ -1,6 +1,12 @@
 import GraphQL
 
-public final class Subscription<Resolver, Context>: Component<Resolver, Context> {
+public final class Subscription<
+    Resolver: Sendable,
+    Context: Sendable
+>: Component<
+    Resolver,
+    Context
+> {
     let fields: [FieldComponent<Resolver, Context>]
 
     let isTypeOf: GraphQLIsTypeOf = { source, _ in

--- a/Sources/Graphiti/Subscription/Subscription.swift
+++ b/Sources/Graphiti/Subscription/Subscription.swift
@@ -3,7 +3,7 @@ import GraphQL
 public final class Subscription<Resolver, Context>: Component<Resolver, Context> {
     let fields: [FieldComponent<Resolver, Context>]
 
-    let isTypeOf: GraphQLIsTypeOf = { source, _, _ in
+    let isTypeOf: GraphQLIsTypeOf = { source, _ in
         source is Resolver
     }
 

--- a/Sources/Graphiti/Type/Type.swift
+++ b/Sources/Graphiti/Type/Type.swift
@@ -1,6 +1,10 @@
 import GraphQL
 
-public final class Type<Resolver, Context, ObjectType>: TypeComponent<
+public final class Type<
+    Resolver: Sendable,
+    Context: Sendable,
+    ObjectType: Sendable
+>: TypeComponent<
     Resolver,
     Context
 > {
@@ -36,6 +40,7 @@ public final class Type<Resolver, Context, ObjectType>: TypeComponent<
 
         // If federation keys are included, create resolver closure
         if !keys.isEmpty {
+            let keys = self.keys
             let resolve: GraphQLFieldResolve = { source, args, context, _ in
                 guard let s = source as? Resolver else {
                     throw GraphQLError(
@@ -49,7 +54,7 @@ public final class Type<Resolver, Context, ObjectType>: TypeComponent<
                     )
                 }
 
-                let keyMatch = self.keys.first { key in
+                let keyMatch = keys.first { key in
                     key.mapMatchesArguments(args, coders: coders)
                 }
                 guard let key = keyMatch else {

--- a/Sources/Graphiti/Type/Type.swift
+++ b/Sources/Graphiti/Type/Type.swift
@@ -8,7 +8,7 @@ public final class Type<Resolver, Context, ObjectType>: TypeComponent<
     var keys: [KeyComponent<ObjectType, Resolver, Context>]
     let fields: [FieldComponent<ObjectType, Context>]
 
-    let isTypeOf: GraphQLIsTypeOf = { source, _, _ in
+    let isTypeOf: GraphQLIsTypeOf = { source, _ in
         source is ObjectType
     }
 
@@ -36,7 +36,7 @@ public final class Type<Resolver, Context, ObjectType>: TypeComponent<
 
         // If federation keys are included, create resolver closure
         if !keys.isEmpty {
-            let resolve: GraphQLFieldResolve = { source, args, context, eventLoopGroup, _ in
+            let resolve: GraphQLFieldResolve = { source, args, context, _ in
                 guard let s = source as? Resolver else {
                     throw GraphQLError(
                         message: "Expected source type \(ObjectType.self) but got \(type(of: source))"
@@ -58,11 +58,10 @@ public final class Type<Resolver, Context, ObjectType>: TypeComponent<
                     )
                 }
 
-                return try key.resolveMap(
+                return try await key.resolveMap(
                     resolver: s,
                     context: c,
                     map: args,
-                    eventLoopGroup: eventLoopGroup,
                     coders: coders
                 )
             }

--- a/Sources/Graphiti/Union/Union.swift
+++ b/Sources/Graphiti/Union/Union.swift
@@ -1,6 +1,13 @@
 import GraphQL
 
-public final class Union<Resolver, Context, UnionType>: TypeComponent<Resolver, Context> {
+public final class Union<
+    Resolver: Sendable,
+    Context: Sendable,
+    UnionType
+>: TypeComponent<
+    Resolver,
+    Context
+> {
     private let members: [Any.Type]
 
     override func update(typeProvider: SchemaTypeProvider, coders _: Coders) throws {

--- a/Sources/Graphiti/Validation/NoIntrospectionRule.swift
+++ b/Sources/Graphiti/Validation/NoIntrospectionRule.swift
@@ -1,5 +1,6 @@
 import GraphQL
 
+@Sendable
 public func NoIntrospectionRule(context: ValidationContext) -> Visitor {
     return Visitor(enter: { node, _, _, _, _ in
         if let field = node as? GraphQL.Field, ["__schema", "__type"].contains(field.name.value) {

--- a/Tests/GraphitiTests/ConnectionTests.swift
+++ b/Tests/GraphitiTests/ConnectionTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Graphiti
-import NIO
 import XCTest
 
 class ConnectionTests: XCTestCase {
@@ -40,35 +39,33 @@ class ConnectionTests: XCTestCase {
         }
     }
 
-    let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-
     /// Test that connection objects work as expected
-    func testConnection() throws {
-        XCTAssertEqual(
-            try schema.execute(
-                request: """
-                {
-                    comments {
-                        edges {
-                            cursor
-                            node {
-                                id
-                                message
-                            }
-                        }
-                        pageInfo {
-                            hasPreviousPage
-                            hasNextPage
-                            startCursor
-                            endCursor
+    func testConnection() async throws {
+        let result = try await schema.execute(
+            request: """
+            {
+                comments {
+                    edges {
+                        cursor
+                        node {
+                            id
+                            message
                         }
                     }
+                    pageInfo {
+                        hasPreviousPage
+                        hasNextPage
+                        startCursor
+                        endCursor
+                    }
                 }
-                """,
-                resolver: .init(),
-                context: NoContext(),
-                eventLoopGroup: eventLoopGroup
-            ).wait(),
+            }
+            """,
+            resolver: .init(),
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             .init(
                 data: [
                     "comments": [
@@ -108,31 +105,31 @@ class ConnectionTests: XCTestCase {
     }
 
     /// Test that `first` argument works as intended
-    func testFirst() throws {
-        XCTAssertEqual(
-            try schema.execute(
-                request: """
-                {
-                    comments(first: 1) {
-                        edges {
-                            node {
-                                id
-                                message
-                            }
-                        }
-                        pageInfo {
-                            hasPreviousPage
-                            hasNextPage
-                            startCursor
-                            endCursor
+    func testFirst() async throws {
+        let result = try await schema.execute(
+            request: """
+            {
+                comments(first: 1) {
+                    edges {
+                        node {
+                            id
+                            message
                         }
                     }
+                    pageInfo {
+                        hasPreviousPage
+                        hasNextPage
+                        startCursor
+                        endCursor
+                    }
                 }
-                """,
-                resolver: .init(),
-                context: NoContext(),
-                eventLoopGroup: eventLoopGroup
-            ).wait(),
+            }
+            """,
+            resolver: .init(),
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             .init(
                 data: [
                     "comments": [
@@ -157,31 +154,31 @@ class ConnectionTests: XCTestCase {
     }
 
     /// Test that `after` argument works as intended
-    func testAfter() throws {
-        XCTAssertEqual(
-            try schema.execute(
-                request: """
-                {
-                    comments(after: "MQ==") {
-                        edges {
-                            node {
-                                id
-                                message
-                            }
-                        }
-                        pageInfo {
-                            hasPreviousPage
-                            hasNextPage
-                            startCursor
-                            endCursor
+    func testAfter() async throws {
+        let result = try await schema.execute(
+            request: """
+            {
+                comments(after: "MQ==") {
+                    edges {
+                        node {
+                            id
+                            message
                         }
                     }
+                    pageInfo {
+                        hasPreviousPage
+                        hasNextPage
+                        startCursor
+                        endCursor
+                    }
                 }
-                """,
-                resolver: .init(),
-                context: NoContext(),
-                eventLoopGroup: eventLoopGroup
-            ).wait(),
+            }
+            """,
+            resolver: .init(),
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             .init(
                 data: [
                     "comments": [
@@ -212,31 +209,31 @@ class ConnectionTests: XCTestCase {
     }
 
     /// Test that mixing `first` and `after` arguments works as intended
-    func testFirstAfter() throws {
-        XCTAssertEqual(
-            try schema.execute(
-                request: """
-                {
-                    comments(first: 1, after: "MQ==") {
-                        edges {
-                            node {
-                                id
-                                message
-                            }
-                        }
-                        pageInfo {
-                            hasPreviousPage
-                            hasNextPage
-                            startCursor
-                            endCursor
+    func testFirstAfter() async throws {
+        let result = try await schema.execute(
+            request: """
+            {
+                comments(first: 1, after: "MQ==") {
+                    edges {
+                        node {
+                            id
+                            message
                         }
                     }
+                    pageInfo {
+                        hasPreviousPage
+                        hasNextPage
+                        startCursor
+                        endCursor
+                    }
                 }
-                """,
-                resolver: .init(),
-                context: NoContext(),
-                eventLoopGroup: eventLoopGroup
-            ).wait(),
+            }
+            """,
+            resolver: .init(),
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             .init(
                 data: [
                     "comments": [
@@ -261,31 +258,31 @@ class ConnectionTests: XCTestCase {
     }
 
     /// Test that `last` argument works as intended
-    func testLast() throws {
-        XCTAssertEqual(
-            try schema.execute(
-                request: """
-                {
-                    comments(last: 1) {
-                        edges {
-                            node {
-                                id
-                                message
-                            }
-                        }
-                        pageInfo {
-                            hasPreviousPage
-                            hasNextPage
-                            startCursor
-                            endCursor
+    func testLast() async throws {
+        let result = try await schema.execute(
+            request: """
+            {
+                comments(last: 1) {
+                    edges {
+                        node {
+                            id
+                            message
                         }
                     }
+                    pageInfo {
+                        hasPreviousPage
+                        hasNextPage
+                        startCursor
+                        endCursor
+                    }
                 }
-                """,
-                resolver: .init(),
-                context: NoContext(),
-                eventLoopGroup: eventLoopGroup
-            ).wait(),
+            }
+            """,
+            resolver: .init(),
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             .init(
                 data: [
                     "comments": [
@@ -310,31 +307,31 @@ class ConnectionTests: XCTestCase {
     }
 
     /// Test that `before` argument works as intended
-    func testBefore() throws {
-        XCTAssertEqual(
-            try schema.execute(
-                request: """
-                {
-                    comments(before: "Mw==") {
-                        edges {
-                            node {
-                                id
-                                message
-                            }
-                        }
-                        pageInfo {
-                            hasPreviousPage
-                            hasNextPage
-                            startCursor
-                            endCursor
+    func testBefore() async throws {
+        let result = try await schema.execute(
+            request: """
+            {
+                comments(before: "Mw==") {
+                    edges {
+                        node {
+                            id
+                            message
                         }
                     }
+                    pageInfo {
+                        hasPreviousPage
+                        hasNextPage
+                        startCursor
+                        endCursor
+                    }
                 }
-                """,
-                resolver: .init(),
-                context: NoContext(),
-                eventLoopGroup: eventLoopGroup
-            ).wait(),
+            }
+            """,
+            resolver: .init(),
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             .init(
                 data: [
                     "comments": [
@@ -365,31 +362,31 @@ class ConnectionTests: XCTestCase {
     }
 
     /// Test that mixing `last` with `before` argument works as intended
-    func testLastBefore() throws {
-        XCTAssertEqual(
-            try schema.execute(
-                request: """
-                {
-                    comments(last: 1, before: "Mw==") {
-                        edges {
-                            node {
-                                id
-                                message
-                            }
-                        }
-                        pageInfo {
-                            hasPreviousPage
-                            hasNextPage
-                            startCursor
-                            endCursor
+    func testLastBefore() async throws {
+        let result = try await schema.execute(
+            request: """
+            {
+                comments(last: 1, before: "Mw==") {
+                    edges {
+                        node {
+                            id
+                            message
                         }
                     }
+                    pageInfo {
+                        hasPreviousPage
+                        hasNextPage
+                        startCursor
+                        endCursor
+                    }
                 }
-                """,
-                resolver: .init(),
-                context: NoContext(),
-                eventLoopGroup: eventLoopGroup
-            ).wait(),
+            }
+            """,
+            resolver: .init(),
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             .init(
                 data: [
                     "comments": [
@@ -414,31 +411,31 @@ class ConnectionTests: XCTestCase {
     }
 
     /// Test that mixing `after` with `before` argument works as intended
-    func testAfterBefore() throws {
-        XCTAssertEqual(
-            try schema.execute(
-                request: """
-                {
-                    comments(after: "MQ==", before: "Mw==") {
-                        edges {
-                            node {
-                                id
-                                message
-                            }
-                        }
-                        pageInfo {
-                            hasPreviousPage
-                            hasNextPage
-                            startCursor
-                            endCursor
+    func testAfterBefore() async throws {
+        let result = try await schema.execute(
+            request: """
+            {
+                comments(after: "MQ==", before: "Mw==") {
+                    edges {
+                        node {
+                            id
+                            message
                         }
                     }
+                    pageInfo {
+                        hasPreviousPage
+                        hasNextPage
+                        startCursor
+                        endCursor
+                    }
                 }
-                """,
-                resolver: .init(),
-                context: NoContext(),
-                eventLoopGroup: eventLoopGroup
-            ).wait(),
+            }
+            """,
+            resolver: .init(),
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             .init(
                 data: [
                     "comments": [
@@ -463,7 +460,7 @@ class ConnectionTests: XCTestCase {
     }
 
     /// Test that adjusting names using `as` works
-    func testNaming() throws {
+    func testNaming() async throws {
         struct ChatObject: Codable {
             func messages(
                 context _: NoContext,
@@ -509,26 +506,26 @@ class ConnectionTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual(
-            try schema.execute(
-                request: """
-                {
-                    chatObject {
-                        messages {
-                            edges {
-                                node {
-                                    id
-                                    text
-                                }
+        let result = try await schema.execute(
+            request: """
+            {
+                chatObject {
+                    messages {
+                        edges {
+                            node {
+                                id
+                                text
                             }
                         }
                     }
                 }
-                """,
-                resolver: .init(),
-                context: NoContext(),
-                eventLoopGroup: eventLoopGroup
-            ).wait(),
+            }
+            """,
+            resolver: .init(),
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             .init(
                 data: [
                     "chatObject": [

--- a/Tests/GraphitiTests/DefaultValueTests.swift
+++ b/Tests/GraphitiTests/DefaultValueTests.swift
@@ -1,120 +1,117 @@
 import Graphiti
 import GraphQL
-import NIO
 import XCTest
 
 class DefaultValueTests: XCTestCase {
-    let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-
     func testBoolDefault() async throws {
+        let result = try await DefaultValueAPI().execute(
+            request: """
+            {
+                bool
+            }
+            """,
+            context: NoContext()
+        )
         XCTAssertEqual(
-            try DefaultValueAPI().execute(
-                request: """
-                {
-                  bool
-                }
-                """,
-                context: NoContext(),
-                on: eventLoopGroup
-            ).wait(),
+            result,
             .init(data: ["bool": true])
         )
     }
 
     func testIntDefault() async throws {
+        let result = try await DefaultValueAPI().execute(
+            request: """
+            {
+                int
+            }
+            """,
+            context: NoContext()
+        )
         XCTAssertEqual(
-            try DefaultValueAPI().execute(
-                request: """
-                {
-                  int
-                }
-                """,
-                context: NoContext(),
-                on: eventLoopGroup
-            ).wait(),
+            result,
             .init(data: ["int": 1])
         )
     }
 
     func testFloatDefault() async throws {
+        let result = try await DefaultValueAPI().execute(
+            request: """
+            {
+                float
+            }
+            """,
+            context: NoContext()
+        )
         XCTAssertEqual(
-            try DefaultValueAPI().execute(
-                request: """
-                {
-                  float
-                }
-                """,
-                context: NoContext(),
-                on: eventLoopGroup
-            ).wait(),
+            result,
             .init(data: ["float": 1.1])
         )
     }
 
     func testStringDefault() async throws {
+        let result = try await DefaultValueAPI().execute(
+            request: """
+            {
+                string
+            }
+            """,
+            context: NoContext()
+        )
         XCTAssertEqual(
-            try DefaultValueAPI().execute(
-                request: """
-                {
-                  string
-                }
-                """,
-                context: NoContext(),
-                on: eventLoopGroup
-            ).wait(),
+            result,
             .init(data: ["string": "hello"])
         )
     }
 
     func testEnumDefault() async throws {
+        let result = try await DefaultValueAPI().execute(
+            request: """
+            {
+                enum
+            }
+            """,
+            context: NoContext()
+        )
         XCTAssertEqual(
-            try DefaultValueAPI().execute(
-                request: """
-                {
-                  enum
-                }
-                """,
-                context: NoContext(),
-                on: eventLoopGroup
-            ).wait(),
+            result,
             .init(data: ["enum": "valueA"])
         )
     }
 
     func testArrayDefault() async throws {
+        let result = try await DefaultValueAPI().execute(
+            request: """
+            {
+                array
+            }
+            """,
+            context: NoContext()
+        )
         XCTAssertEqual(
-            try DefaultValueAPI().execute(
-                request: """
-                {
-                  array
-                }
-                """,
-                context: NoContext(),
-                on: eventLoopGroup
-            ).wait(),
+            result,
             .init(data: ["array": ["a", "b", "c"]])
         )
     }
 
     func testInputDefault() async throws {
         // Test input object argument default
-        XCTAssertEqual(
-            try DefaultValueAPI().execute(
-                request: """
-                {
-                  input {
-                    bool
-                    int
-                    float
-                    string
-                    enum
-                    array
-                  }
+        var result = try await DefaultValueAPI().execute(
+            request: """
+            {
+                input {
+                bool
+                int
+                float
+                string
+                enum
+                array
                 }
-                """,
-                context: NoContext(),
-                on: eventLoopGroup
-            ).wait(),
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             .init(data: [
                 "input": [
                     "bool": true,
@@ -128,23 +125,23 @@ class DefaultValueTests: XCTestCase {
         )
 
         // Test input object field defaults
-        XCTAssertEqual(
-            try DefaultValueAPI().execute(
-                request: """
-                {
-                  input(input: {bool: true}) {
-                    bool
-                    int
-                    float
-                    string
-                    enum
-                    array
-                  }
+        result = try await DefaultValueAPI().execute(
+            request: """
+            {
+                input(input: {bool: true}) {
+                bool
+                int
+                float
+                string
+                enum
+                array
                 }
-                """,
-                context: NoContext(),
-                on: eventLoopGroup
-            ).wait(),
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             .init(data: [
                 "input": [
                     "bool": true,

--- a/Tests/GraphitiTests/FederationTests/FederationTests.swift
+++ b/Tests/GraphitiTests/FederationTests/FederationTests.swift
@@ -1,11 +1,9 @@
 import Foundation
 import Graphiti
 import GraphQL
-import NIO
 import XCTest
 
 final class FederationTests: XCTestCase {
-    private var group: MultiThreadedEventLoopGroup!
     private var api: ProductAPI!
 
     override func setUpWithError() throws {
@@ -13,35 +11,37 @@ final class FederationTests: XCTestCase {
             .use(partials: [ProductSchema()])
             .setFederatedSDL(to: loadSDL())
             .build()
-        group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
         api = try ProductAPI(resolver: ProductResolver(sdl: loadSDL()), schema: schema)
     }
 
     override func tearDownWithError() throws {
-        try group.syncShutdownGracefully()
-        group = nil
         api = nil
     }
 
     // Test Queries from https://github.com/apollographql/apollo-federation-subgraph-compatibility/blob/main/COMPATIBILITY.md
 
-    func testServiceQuery() throws {
-        try XCTAssertEqual(execute(request: query("service")), GraphQLResult(data: [
-            "_service": [
-                "sdl": Map(stringLiteral: loadSDL()),
-            ],
-        ]))
+    func testServiceQuery() async throws {
+        let result = try await execute(request: query("service"))
+        try XCTAssertEqual(
+            result,
+            GraphQLResult(data: [
+                "_service": [
+                    "sdl": Map(stringLiteral: loadSDL()),
+                ],
+            ])
+        )
     }
 
-    func testEntityKey() throws {
+    func testEntityKey() async throws {
         let representations: [String: Map] = [
             "representations": [
                 ["__typename": "User", "email": "support@apollographql.com"],
             ],
         ]
 
-        try XCTAssertEqual(
-            execute(request: query("entities"), variables: representations),
+        let result = try await execute(request: query("entities"), variables: representations)
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "_entities": [
                     [
@@ -56,7 +56,7 @@ final class FederationTests: XCTestCase {
         )
     }
 
-    func testEntityMultipleKey() throws {
+    func testEntityMultipleKey() async throws {
         let representations: [String: Map] = [
             "representations": [
                 [
@@ -67,8 +67,9 @@ final class FederationTests: XCTestCase {
             ],
         ]
 
-        try XCTAssertEqual(
-            execute(request: query("entities"), variables: representations),
+        let result = try await execute(request: query("entities"), variables: representations)
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "_entities": [
                     [
@@ -88,15 +89,16 @@ final class FederationTests: XCTestCase {
         )
     }
 
-    func testEntityCompositeKey() throws {
+    func testEntityCompositeKey() async throws {
         let representations: [String: Map] = [
             "representations": [
                 ["__typename": "ProductResearch", "study": ["caseNumber": "1234"]],
             ],
         ]
 
-        try XCTAssertEqual(
-            execute(request: query("entities"), variables: representations),
+        let result = try await execute(request: query("entities"), variables: representations)
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "_entities": [
                     [
@@ -111,7 +113,7 @@ final class FederationTests: XCTestCase {
         )
     }
 
-    func testEntityMultipleKeys() throws {
+    func testEntityMultipleKeys() async throws {
         let representations: [String: Map] = [
             "representations": [
                 ["__typename": "Product", "id": "apollo-federation"],
@@ -120,8 +122,9 @@ final class FederationTests: XCTestCase {
             ],
         ]
 
-        try XCTAssertEqual(
-            execute(request: query("entities"), variables: representations),
+        let result = try await execute(request: query("entities"), variables: representations)
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "_entities": [
                     [
@@ -253,9 +256,7 @@ extension FederationTests {
         return try String(contentsOf: url)
     }
 
-    func execute(request: String, variables: [String: Map] = [:]) throws -> GraphQLResult {
-        try api
-            .execute(request: request, context: ProductContext(), on: group, variables: variables)
-            .wait()
+    func execute(request: String, variables: [String: Map] = [:]) async throws -> GraphQLResult {
+        try await api.execute(request: request, context: ProductContext(), variables: variables)
     }
 }

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
@@ -19,15 +19,15 @@ extension HelloResolver {
     func subscribeUser(
         context _: HelloContext,
         arguments _: NoArguments
-    ) -> AsyncThrowingStream<User, Error> {
-        pubsub.subscribe()
+    ) async -> AsyncThrowingStream<User, Error> {
+        await pubsub.subscribe()
     }
 
     func futureSubscribeUser(
         context _: HelloContext,
         arguments _: NoArguments
-    ) -> AsyncThrowingStream<User, Error> {
-        pubsub.subscribe()
+    ) async -> AsyncThrowingStream<User, Error> {
+        await pubsub.subscribe()
     }
 
     func asyncSubscribeUser(
@@ -35,7 +35,7 @@ extension HelloResolver {
         arguments _: NoArguments
     ) async -> AsyncThrowingStream<User, Error> {
         return await Task {
-            pubsub.subscribe()
+            await pubsub.subscribe()
         }.value
     }
 }
@@ -168,7 +168,7 @@ class HelloWorldAsyncTests: XCTestCase {
         ).get()
         var iterator = subscription.makeAsyncIterator()
 
-        pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
+        await pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
 
         let result = try await iterator.next()
         XCTAssertEqual(
@@ -201,7 +201,7 @@ class HelloWorldAsyncTests: XCTestCase {
         ).get()
         var iterator = subscription.makeAsyncIterator()
 
-        pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
+        await pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
 
         let result = try await iterator.next()
         XCTAssertEqual(
@@ -234,7 +234,7 @@ class HelloWorldAsyncTests: XCTestCase {
         ).get()
         var iterator = subscription.makeAsyncIterator()
 
-        pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
+        await pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
 
         let result = try await iterator.next()
         XCTAssertEqual(
@@ -265,7 +265,7 @@ class HelloWorldAsyncTests: XCTestCase {
         ).get()
         var iterator = subscription.makeAsyncIterator()
 
-        pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
+        await pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
 
         let result = try await iterator.next()
         XCTAssertEqual(
@@ -282,7 +282,7 @@ class HelloWorldAsyncTests: XCTestCase {
 
 /// A very simple publish/subscriber used for testing
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
-class SimplePubSub<T> {
+actor SimplePubSub<T: Sendable>: Sendable {
     private var subscribers: [Subscriber<T>]
 
     init() {
@@ -316,7 +316,7 @@ class SimplePubSub<T> {
     }
 }
 
-struct Subscriber<T> {
+struct Subscriber<T: Sendable> {
     let callback: (T) -> Void
     let cancel: () -> Void
 }

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldAsyncTests.swift
@@ -1,6 +1,5 @@
 @testable import Graphiti
 import GraphQL
-import NIO
 import XCTest
 
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
@@ -17,22 +16,24 @@ extension HelloResolver {
         }.value
     }
 
-    func subscribeUser(context _: HelloContext, arguments _: NoArguments) -> EventStream<User> {
+    func subscribeUser(
+        context _: HelloContext,
+        arguments _: NoArguments
+    ) -> AsyncThrowingStream<User, Error> {
         pubsub.subscribe()
     }
 
     func futureSubscribeUser(
         context _: HelloContext,
-        arguments _: NoArguments,
-        group: EventLoopGroup
-    ) -> EventLoopFuture<EventStream<User>> {
-        group.next().makeSucceededFuture(pubsub.subscribe())
+        arguments _: NoArguments
+    ) -> AsyncThrowingStream<User, Error> {
+        pubsub.subscribe()
     }
 
     func asyncSubscribeUser(
         context _: HelloContext,
         arguments _: NoArguments
-    ) async -> EventStream<User> {
+    ) async -> AsyncThrowingStream<User, Error> {
         return await Task {
             pubsub.subscribe()
         }.value
@@ -123,15 +124,13 @@ struct HelloAsyncAPI: API {
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 class HelloWorldAsyncTests: XCTestCase {
     private let api = HelloAsyncAPI()
-    private var group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
     /// Tests that async version of API.execute works as expected
     func testAsyncExecute() async throws {
         let query = "{ hello }"
         let result = try await api.execute(
             request: query,
-            context: api.context,
-            on: group
+            context: api.context
         )
         XCTAssertEqual(
             result,
@@ -144,8 +143,7 @@ class HelloWorldAsyncTests: XCTestCase {
         let query = "{ asyncHello }"
         let result = try await api.execute(
             request: query,
-            context: api.context,
-            on: group
+            context: api.context
         )
         XCTAssertEqual(
             result,
@@ -164,24 +162,15 @@ class HelloWorldAsyncTests: XCTestCase {
         }
         """
 
-        let subscriptionResult = try await api.subscribe(
+        let subscription = try await api.subscribe(
             request: request,
-            context: api.context,
-            on: group
-        )
-        guard let subscription = subscriptionResult.stream else {
-            XCTFail(subscriptionResult.errors.description)
-            return
-        }
-        guard let stream = subscription as? ConcurrentEventStream else {
-            XCTFail("stream isn't ConcurrentEventStream")
-            return
-        }
-        var iterator = stream.stream.makeAsyncIterator()
+            context: api.context
+        ).get()
+        var iterator = subscription.makeAsyncIterator()
 
         pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
 
-        let result = try await iterator.next()?.get()
+        let result = try await iterator.next()
         XCTAssertEqual(
             result,
             GraphQLResult(data: [
@@ -206,24 +195,15 @@ class HelloWorldAsyncTests: XCTestCase {
         }
         """
 
-        let subscriptionResult = try await api.subscribe(
+        let subscription = try await api.subscribe(
             request: request,
-            context: api.context,
-            on: group
-        )
-        guard let subscription = subscriptionResult.stream else {
-            XCTFail(subscriptionResult.errors.description)
-            return
-        }
-        guard let stream = subscription as? ConcurrentEventStream else {
-            XCTFail("stream isn't ConcurrentEventStream")
-            return
-        }
-        var iterator = stream.stream.makeAsyncIterator()
+            context: api.context
+        ).get()
+        var iterator = subscription.makeAsyncIterator()
 
         pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
 
-        let result = try await iterator.next()?.get()
+        let result = try await iterator.next()
         XCTAssertEqual(
             result,
             GraphQLResult(data: [
@@ -248,24 +228,15 @@ class HelloWorldAsyncTests: XCTestCase {
         }
         """
 
-        let subscriptionResult = try await api.subscribe(
+        let subscription = try await api.subscribe(
             request: request,
-            context: api.context,
-            on: group
-        )
-        guard let subscription = subscriptionResult.stream else {
-            XCTFail(subscriptionResult.errors.description)
-            return
-        }
-        guard let stream = subscription as? ConcurrentEventStream else {
-            XCTFail("stream isn't ConcurrentEventStream")
-            return
-        }
-        var iterator = stream.stream.makeAsyncIterator()
+            context: api.context
+        ).get()
+        var iterator = subscription.makeAsyncIterator()
 
         pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
 
-        let result = try await iterator.next()?.get()
+        let result = try await iterator.next()
         XCTAssertEqual(
             result,
             GraphQLResult(data: [
@@ -288,24 +259,15 @@ class HelloWorldAsyncTests: XCTestCase {
         }
         """
 
-        let subscriptionResult = try await api.subscribe(
+        let subscription = try await api.subscribe(
             request: request,
-            context: api.context,
-            on: group
-        )
-        guard let subscription = subscriptionResult.stream else {
-            XCTFail(subscriptionResult.errors.description)
-            return
-        }
-        guard let stream = subscription as? ConcurrentEventStream else {
-            XCTFail("stream isn't ConcurrentEventStream")
-            return
-        }
-        var iterator = stream.stream.makeAsyncIterator()
+            context: api.context
+        ).get()
+        var iterator = subscription.makeAsyncIterator()
 
         pubsub.publish(event: User(id: "124", name: "Jerry", friends: nil))
 
-        let result = try await iterator.next()?.get()
+        let result = try await iterator.next()
         XCTAssertEqual(
             result,
             GraphQLResult(data: [
@@ -339,8 +301,8 @@ class SimplePubSub<T> {
         }
     }
 
-    func subscribe() -> ConcurrentEventStream<T> {
-        let asyncStream = AsyncThrowingStream<T, Error> { continuation in
+    func subscribe() -> AsyncThrowingStream<T, Error> {
+        return AsyncThrowingStream<T, Error> { continuation in
             let subscriber = Subscriber<T>(
                 callback: { newValue in
                     continuation.yield(newValue)
@@ -351,7 +313,6 @@ class SimplePubSub<T> {
             )
             subscribers.append(subscriber)
         }
-        return ConcurrentEventStream<T>(asyncStream)
     }
 }
 

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
@@ -56,7 +56,7 @@ struct UserEvent {
     let user: User
 }
 
-final class HelloContext {
+final class HelloContext: Sendable {
     func hello() -> String {
         "world"
     }

--- a/Tests/GraphitiTests/PartialSchemaTests.swift
+++ b/Tests/GraphitiTests/PartialSchemaTests.swift
@@ -11,7 +11,7 @@ class PartialSchemaTests: XCTestCase {
                     .description("The id of the character.")
                 Field("name", at: \.name)
                     .description("The name of the character.")
-                Field("friends", at: \.friends)
+                Field("friends", at: Character.getFriends)
                     .description(
                         "The friends of the character, or an empty list if they have none."
                     )
@@ -199,7 +199,7 @@ class PartialSchemaTests: XCTestCase {
                         .description("The id of the character.")
                     Field("name", at: \.name)
                         .description("The name of the character.")
-                    Field("friends", at: \.friends)
+                    Field("friends", at: Character.getFriends)
                         .description(
                             "The friends of the character, or an empty list if they have none."
                         )

--- a/Tests/GraphitiTests/PartialSchemaTests.swift
+++ b/Tests/GraphitiTests/PartialSchemaTests.swift
@@ -1,6 +1,5 @@
 import Graphiti
 import GraphQL
-import NIO
 import XCTest
 
 class PartialSchemaTests: XCTestCase {
@@ -96,13 +95,7 @@ class PartialSchemaTests: XCTestCase {
         }
     }
 
-    func testPartialSchemaWithBuilder() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-
-        defer {
-            try? group.syncShutdownGracefully()
-        }
-
+    func testPartialSchemaWithBuilder() async throws {
         let builder = SchemaBuilder(StarWarsResolver.self, StarWarsContext.self)
 
         builder.use(partials: [BaseSchema(), SearchSchema()])
@@ -116,18 +109,18 @@ class PartialSchemaTests: XCTestCase {
 
         let api = PartialSchemaTestAPI(resolver: StarWarsResolver(), schema: schema)
 
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                    human(id: "1000") {
-                        name
-                    }
+        let result = try await api.execute(
+            request: """
+            query {
+                human(id: "1000") {
+                    name
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "human": [
                     "name": "Luke Skywalker",
@@ -136,13 +129,7 @@ class PartialSchemaTests: XCTestCase {
         )
     }
 
-    func testPartialSchema() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-
-        defer {
-            try? group.syncShutdownGracefully()
-        }
-
+    func testPartialSchema() async throws {
         /// Double check if static func works and the types are inferred properly
         let schema = try Schema.create(from: [BaseSchema(), SearchSchema()])
 
@@ -153,18 +140,18 @@ class PartialSchemaTests: XCTestCase {
 
         let api = PartialSchemaTestAPI(resolver: StarWarsResolver(), schema: schema)
 
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                    human(id: "1000") {
-                        name
-                    }
+        let result = try await api.execute(
+            request: """
+            query {
+                human(id: "1000") {
+                    name
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "human": [
                     "name": "Luke Skywalker",
@@ -173,13 +160,7 @@ class PartialSchemaTests: XCTestCase {
         )
     }
 
-    func testPartialSchemaOutOfOrder() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-
-        defer {
-            try? group.syncShutdownGracefully()
-        }
-
+    func testPartialSchemaOutOfOrder() async throws {
         /// Double check if ordering of partial schema doesn't matter
         let schema = try Schema.create(from: [SearchSchema(), BaseSchema()])
 
@@ -190,18 +171,18 @@ class PartialSchemaTests: XCTestCase {
 
         let api = PartialSchemaTestAPI(resolver: StarWarsResolver(), schema: schema)
 
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                    human(id: "1000") {
-                        name
-                    }
+        let result = try await api.execute(
+            request: """
+            query {
+                human(id: "1000") {
+                    name
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "human": [
                     "name": "Luke Skywalker",
@@ -210,7 +191,7 @@ class PartialSchemaTests: XCTestCase {
         )
     }
 
-    func testInstancePartialSchema() throws {
+    func testInstancePartialSchema() async throws {
         let baseSchema = PartialSchema<StarWarsResolver, StarWarsContext>(
             types: {
                 Interface(Character.self) {
@@ -301,12 +282,6 @@ class PartialSchemaTests: XCTestCase {
             }
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-
-        defer {
-            try? group.syncShutdownGracefully()
-        }
-
         /// Double check if ordering of partial schema doesn't matter
         let schema = try Schema.create(from: [searchSchema, baseSchema])
 
@@ -317,18 +292,18 @@ class PartialSchemaTests: XCTestCase {
 
         let api = PartialSchemaTestAPI(resolver: StarWarsResolver(), schema: schema)
 
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                    human(id: "1000") {
-                        name
-                    }
+        let result = try await api.execute(
+            request: """
+            query {
+                human(id: "1000") {
+                    name
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "human": [
                     "name": "Luke Skywalker",

--- a/Tests/GraphitiTests/ProductAPI/ProductResolver.swift
+++ b/Tests/GraphitiTests/ProductAPI/ProductResolver.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Graphiti
 import GraphQL
-import NIO
 
 struct ProductResolver {
     var sdl: String

--- a/Tests/GraphitiTests/ScalarTests.swift
+++ b/Tests/GraphitiTests/ScalarTests.swift
@@ -656,7 +656,7 @@ class ScalarTests: XCTestCase {
     }
 }
 
-private class TestAPI<Resolver, ContextType>: API {
+private class TestAPI<Resolver: Sendable, ContextType: Sendable>: API {
     public let resolver: Resolver
     public let schema: Schema<Resolver, ContextType>
 

--- a/Tests/GraphitiTests/ScalarTests.swift
+++ b/Tests/GraphitiTests/ScalarTests.swift
@@ -1,13 +1,12 @@
 import Foundation
 @testable import Graphiti
 import GraphQL
-import NIO
 import XCTest
 
 class ScalarTests: XCTestCase {
     // MARK: Test UUID converts to String as expected
 
-    func testUUIDOutput() throws {
+    func testUUIDOutput() async throws {
         struct UUIDOutput {
             let value: UUID
         }
@@ -32,21 +31,18 @@ class ScalarTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                  uuid {
-                    value
-                  }
+        let result = try await api.execute(
+            request: """
+            query {
+                uuid {
+                value
                 }
-                """,
-                context: NoContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "uuid": [
                     "value": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
@@ -55,7 +51,7 @@ class ScalarTests: XCTestCase {
         )
     }
 
-    func testUUIDArg() throws {
+    func testUUIDArg() async throws {
         struct UUIDOutput {
             let value: UUID
         }
@@ -86,21 +82,18 @@ class ScalarTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                  uuid (value: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F") {
-                    value
-                  }
+        let result = try await api.execute(
+            request: """
+            query {
+                uuid (value: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F") {
+                value
                 }
-                """,
-                context: NoContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "uuid": [
                     "value": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
@@ -109,7 +102,7 @@ class ScalarTests: XCTestCase {
         )
     }
 
-    func testUUIDInput() throws {
+    func testUUIDInput() async throws {
         struct UUIDOutput {
             let value: UUID
         }
@@ -147,21 +140,18 @@ class ScalarTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                  uuid (input: {value: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"}) {
-                    value
-                  }
+        let result = try await api.execute(
+            request: """
+            query {
+                uuid (input: {value: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"}) {
+                value
                 }
-                """,
-                context: NoContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "uuid": [
                     "value": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
@@ -172,7 +162,7 @@ class ScalarTests: XCTestCase {
 
     // MARK: Test Date scalars convert to String using ISO8601 encoders
 
-    func testDateOutput() throws {
+    func testDateOutput() async throws {
         struct DateOutput {
             let value: Date
         }
@@ -202,21 +192,18 @@ class ScalarTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                  date {
-                    value
-                  }
+        let result = try await api.execute(
+            request: """
+            query {
+                date {
+                value
                 }
-                """,
-                context: NoContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "date": [
                     "value": "2001-01-01T00:00:00Z",
@@ -225,7 +212,7 @@ class ScalarTests: XCTestCase {
         )
     }
 
-    func testDateArg() throws {
+    func testDateArg() async throws {
         struct DateOutput {
             let value: Date
         }
@@ -261,21 +248,18 @@ class ScalarTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                  date (value: "2001-01-01T00:00:00Z") {
-                    value
-                  }
+        let result = try await api.execute(
+            request: """
+            query {
+                date (value: "2001-01-01T00:00:00Z") {
+                value
                 }
-                """,
-                context: NoContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "date": [
                     "value": "2001-01-01T00:00:00Z",
@@ -284,7 +268,7 @@ class ScalarTests: XCTestCase {
         )
     }
 
-    func testDateInput() throws {
+    func testDateInput() async throws {
         struct DateOutput {
             let value: Date
         }
@@ -327,21 +311,18 @@ class ScalarTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                  date (input: {value: "2001-01-01T00:00:00Z"}) {
-                    value
-                  }
+        let result = try await api.execute(
+            request: """
+            query {
+                date (input: {value: "2001-01-01T00:00:00Z"}) {
+                value
                 }
-                """,
-                context: NoContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "date": [
                     "value": "2001-01-01T00:00:00Z",
@@ -352,7 +333,7 @@ class ScalarTests: XCTestCase {
 
     // MARK: Test a scalar that converts to a single-value Map (StringCodedCoordinate -> String)
 
-    func testStringCoordOutput() throws {
+    func testStringCoordOutput() async throws {
         struct CoordinateOutput {
             let value: StringCodedCoordinate
         }
@@ -377,21 +358,18 @@ class ScalarTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                  coord {
-                    value
-                  }
+        let result = try await api.execute(
+            request: """
+            query {
+                coord {
+                value
                 }
-                """,
-                context: NoContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "coord": [
                     "value": "(0.0, 0.0)",
@@ -400,7 +378,7 @@ class ScalarTests: XCTestCase {
         )
     }
 
-    func testStringCoordArg() throws {
+    func testStringCoordArg() async throws {
         struct CoordinateOutput {
             let value: StringCodedCoordinate
         }
@@ -431,21 +409,18 @@ class ScalarTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                  coord (value: "(0.0, 0.0)") {
-                    value
-                  }
+        let result = try await api.execute(
+            request: """
+            query {
+                coord (value: "(0.0, 0.0)") {
+                value
                 }
-                """,
-                context: NoContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "coord": [
                     "value": "(0.0, 0.0)",
@@ -454,7 +429,7 @@ class ScalarTests: XCTestCase {
         )
     }
 
-    func testStringCoordInput() throws {
+    func testStringCoordInput() async throws {
         struct CoordinateOutput {
             let value: StringCodedCoordinate
         }
@@ -492,21 +467,18 @@ class ScalarTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                  coord (input: {value: "(0.0, 0.0)"}) {
-                    value
-                  }
+        let result = try await api.execute(
+            request: """
+            query {
+                coord (input: {value: "(0.0, 0.0)"}) {
+                value
                 }
-                """,
-                context: NoContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "coord": [
                     "value": "(0.0, 0.0)",
@@ -517,7 +489,7 @@ class ScalarTests: XCTestCase {
 
     // MARK: Test a scalar that converts to a multi-value Map (Coordinate -> Dict)
 
-    func testDictCoordOutput() throws {
+    func testDictCoordOutput() async throws {
         struct CoordinateOutput {
             let value: DictCodedCoordinate
         }
@@ -542,11 +514,8 @@ class ScalarTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
         // Test individual fields because we can't be confident we'll match the ordering of Map's OrderedDictionary
-        let result = try api.execute(
+        let result = try await api.execute(
             request: """
             query {
               coord {
@@ -554,9 +523,9 @@ class ScalarTests: XCTestCase {
               }
             }
             """,
-            context: NoContext(),
-            on: group
-        ).wait()
+            context: NoContext()
+        )
+
         let value = result.data?.dictionary?["coord"]?.dictionary?["value"]?.dictionary
 
         XCTAssertEqual(
@@ -569,7 +538,7 @@ class ScalarTests: XCTestCase {
         )
     }
 
-    func testDictCoordArg() throws {
+    func testDictCoordArg() async throws {
         struct CoordinateOutput {
             let value: DictCodedCoordinate
         }
@@ -600,11 +569,8 @@ class ScalarTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
         // Test individual fields because we can't be confident we'll match the ordering of Map's OrderedDictionary
-        let result = try api.execute(
+        let result = try await api.execute(
             request: """
             query {
               coord (value: {latitude: 0.0, longitude: 0.0}) {
@@ -612,9 +578,9 @@ class ScalarTests: XCTestCase {
               }
             }
             """,
-            context: NoContext(),
-            on: group
-        ).wait()
+            context: NoContext()
+        )
+
         let value = result.data?.dictionary?["coord"]?.dictionary?["value"]?.dictionary
 
         XCTAssertEqual(
@@ -627,7 +593,7 @@ class ScalarTests: XCTestCase {
         )
     }
 
-    func testDictCoordInput() throws {
+    func testDictCoordInput() async throws {
         struct CoordinateOutput {
             let value: DictCodedCoordinate
         }
@@ -665,11 +631,8 @@ class ScalarTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
         // Test individual fields because we can't be confident we'll match the ordering of Map's OrderedDictionary
-        let result = try api.execute(
+        let result = try await api.execute(
             request: """
             query {
               coord (input: {value: {latitude: 0.0, longitude: 0.0}}) {
@@ -677,9 +640,9 @@ class ScalarTests: XCTestCase {
               }
             }
             """,
-            context: NoContext(),
-            on: group
-        ).wait()
+            context: NoContext()
+        )
+
         let value = result.data?.dictionary?["coord"]?.dictionary?["value"]?.dictionary
 
         XCTAssertEqual(

--- a/Tests/GraphitiTests/SchemaBuilderTests.swift
+++ b/Tests/GraphitiTests/SchemaBuilderTests.swift
@@ -67,7 +67,7 @@ class SchemaBuilderTests: XCTestCase {
                     .description("The id of the character.")
                 Field("name", at: \.name)
                     .description("The name of the character.")
-                Field("friends", at: \.friends)
+                Field("friends", at: Character.getFriends)
                     .description(
                         "The friends of the character, or an empty list if they have none."
                     )

--- a/Tests/GraphitiTests/SchemaBuilderTests.swift
+++ b/Tests/GraphitiTests/SchemaBuilderTests.swift
@@ -1,12 +1,9 @@
 import Graphiti
 import GraphQL
-import NIO
 import XCTest
 
 class SchemaBuilderTests: XCTestCase {
-    func testSchemaBuilder() throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-
+    func testSchemaBuilder() async throws {
         let builder = SchemaBuilder(StarWarsResolver.self, StarWarsContext.self)
 
         // Add assets slightly out of order
@@ -104,18 +101,18 @@ class SchemaBuilderTests: XCTestCase {
 
         let api = SchemaBuilderTestAPI(resolver: StarWarsResolver(), schema: schema)
 
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                    human(id: "1000") {
-                        name
-                    }
+        let result = try await api.execute(
+            request: """
+            query {
+                human(id: "1000") {
+                    name
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "human": [
                     "name": "Luke Skywalker",

--- a/Tests/GraphitiTests/SchemaTests.swift
+++ b/Tests/GraphitiTests/SchemaTests.swift
@@ -158,7 +158,7 @@ class SchemaTests: XCTestCase {
     }
 }
 
-private class TestAPI<Resolver, ContextType>: API {
+private class TestAPI<Resolver: Sendable, ContextType: Sendable>: API {
     public let resolver: Resolver
     public let schema: Schema<Resolver, ContextType>
 

--- a/Tests/GraphitiTests/SchemaTests.swift
+++ b/Tests/GraphitiTests/SchemaTests.swift
@@ -142,7 +142,7 @@ class SchemaTests: XCTestCase {
         struct TestResolver {}
 
         do {
-            let _ = try Schema<TestResolver, NoContext> {
+            _ = try Schema<TestResolver, NoContext> {
                 Type(User.self) {
                     Field("id", at: \.id)
                 }

--- a/Tests/GraphitiTests/SchemaTests.swift
+++ b/Tests/GraphitiTests/SchemaTests.swift
@@ -1,12 +1,11 @@
 import Foundation
 @testable import Graphiti
 import GraphQL
-import NIO
 import XCTest
 
 class SchemaTests: XCTestCase {
     // Tests that circularly dependent objects can be used in schema and resolved correctly
-    func testCircularDependencies() throws {
+    func testCircularDependencies() async throws {
         struct A: Codable {
             let name: String
             var b: B {
@@ -45,23 +44,20 @@ class SchemaTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                  a {
-                    b {
-                      name
-                    }
-                  }
+        let result = try await api.execute(
+            request: """
+            query {
+                a {
+                b {
+                    name
                 }
-                """,
-                context: NoContext(),
-                on: group
-            ).wait(),
+                }
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "a": [
                     "b": [
@@ -73,7 +69,7 @@ class SchemaTests: XCTestCase {
     }
 
     // Tests that we can resolve type references for named types
-    func testTypeReferenceForNamedType() throws {
+    func testTypeReferenceForNamedType() async throws {
         struct LocationObject: Codable {
             let id: String
             let name: String
@@ -114,23 +110,20 @@ class SchemaTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                  user {
-                    location {
-                      name
-                    }
-                  }
+        let result = try await api.execute(
+            request: """
+            query {
+                user {
+                location {
+                    name
                 }
-                """,
-                context: NoContext(),
-                on: group
-            ).wait(),
+                }
+            }
+            """,
+            context: NoContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(data: [
                 "user": [
                     "location": [

--- a/Tests/GraphitiTests/StarWarsAPI/StarWarsContext.swift
+++ b/Tests/GraphitiTests/StarWarsAPI/StarWarsContext.swift
@@ -5,8 +5,8 @@
  * fetching this data from a backend service rather than from hardcoded
  * values in a more complex demo.
  */
-public final class StarWarsContext {
-    private static var tatooine = Planet(
+public final class StarWarsContext: Sendable {
+    private static let tatooine = Planet(
         id: "10001",
         name: "Tatooine",
         diameter: 10465,
@@ -15,7 +15,7 @@ public final class StarWarsContext {
         residents: []
     )
 
-    private static var alderaan = Planet(
+    private static let alderaan = Planet(
         id: "10002",
         name: "Alderaan",
         diameter: 12500,
@@ -24,12 +24,12 @@ public final class StarWarsContext {
         residents: []
     )
 
-    private static var planetData: [String: Planet] = [
+    private static let planetData: [String: Planet] = [
         "10001": tatooine,
         "10002": alderaan,
     ]
 
-    private static var luke = Human(
+    private static let luke = Human(
         id: "1000",
         name: "Luke Skywalker",
         friends: ["1002", "1003", "2000", "2001"],
@@ -37,7 +37,7 @@ public final class StarWarsContext {
         homePlanet: tatooine
     )
 
-    private static var vader = Human(
+    private static let vader = Human(
         id: "1001",
         name: "Darth Vader",
         friends: ["1004"],
@@ -45,7 +45,7 @@ public final class StarWarsContext {
         homePlanet: tatooine
     )
 
-    private static var han = Human(
+    private static let han = Human(
         id: "1002",
         name: "Han Solo",
         friends: ["1000", "1003", "2001"],
@@ -53,7 +53,7 @@ public final class StarWarsContext {
         homePlanet: alderaan
     )
 
-    private static var leia = Human(
+    private static let leia = Human(
         id: "1003",
         name: "Leia Organa",
         friends: ["1000", "1002", "2000", "2001"],
@@ -61,7 +61,7 @@ public final class StarWarsContext {
         homePlanet: alderaan
     )
 
-    private static var tarkin = Human(
+    private static let tarkin = Human(
         id: "1004",
         name: "Wilhuff Tarkin",
         friends: ["1001"],
@@ -69,7 +69,7 @@ public final class StarWarsContext {
         homePlanet: alderaan
     )
 
-    private static var humanData: [String: Human] = [
+    private static let humanData: [String: Human] = [
         "1000": luke,
         "1001": vader,
         "1002": han,
@@ -77,7 +77,7 @@ public final class StarWarsContext {
         "1004": tarkin,
     ]
 
-    private static var c3po = Droid(
+    private static let c3po = Droid(
         id: "2000",
         name: "C-3PO",
         friends: ["1000", "1002", "1003", "2001"],
@@ -85,7 +85,7 @@ public final class StarWarsContext {
         primaryFunction: "Protocol"
     )
 
-    private static var r2d2 = Droid(
+    private static let r2d2 = Droid(
         id: "2001",
         name: "R2-D2",
         friends: ["1000", "1002", "1003"],
@@ -93,7 +93,7 @@ public final class StarWarsContext {
         primaryFunction: "Astromech"
     )
 
-    private static var droidData: [String: Droid] = [
+    private static let droidData: [String: Droid] = [
         "2000": c3po,
         "2001": r2d2,
     ]

--- a/Tests/GraphitiTests/StarWarsAPI/StarWarsEntities.swift
+++ b/Tests/GraphitiTests/StarWarsAPI/StarWarsEntities.swift
@@ -1,17 +1,17 @@
-public enum Episode: String, CaseIterable, Codable {
+public enum Episode: String, CaseIterable, Codable, Sendable {
     case newHope = "NEWHOPE"
     case empire = "EMPIRE"
     case jedi = "JEDI"
 }
 
-public protocol Character {
+public protocol Character: Sendable {
     var id: String { get }
     var name: String { get }
     var friends: [String] { get }
     var appearsIn: [Episode] { get }
 }
 
-public protocol SearchResult {}
+public protocol SearchResult: Sendable {}
 
 public struct Planet: SearchResult {
     public let id: String

--- a/Tests/GraphitiTests/StarWarsAPI/StarWarsResolver.swift
+++ b/Tests/GraphitiTests/StarWarsAPI/StarWarsResolver.swift
@@ -30,10 +30,10 @@ public extension Droid {
     }
 }
 
-public struct StarWarsResolver {
+public struct StarWarsResolver: Sendable {
     public init() {}
 
-    public struct HeroArguments: Codable {
+    public struct HeroArguments: Codable, Sendable {
         public let episode: Episode?
     }
 
@@ -41,7 +41,7 @@ public struct StarWarsResolver {
         context.getHero(of: arguments.episode)
     }
 
-    public struct HumanArguments: Codable {
+    public struct HumanArguments: Codable, Sendable {
         public let id: String
     }
 
@@ -49,7 +49,7 @@ public struct StarWarsResolver {
         context.getHuman(id: arguments.id)
     }
 
-    public struct DroidArguments: Codable {
+    public struct DroidArguments: Codable, Sendable {
         public let id: String
     }
 
@@ -57,7 +57,7 @@ public struct StarWarsResolver {
         context.getDroid(id: arguments.id)
     }
 
-    public struct SearchArguments: Codable {
+    public struct SearchArguments: Codable, Sendable {
         public let query: String
     }
 

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
@@ -1,32 +1,26 @@
 import GraphQL
-import NIO
 import XCTest
 
 @testable import Graphiti
 
 class StarWarsIntrospectionTests: XCTestCase {
     private let api = StarWarsAPI()
-    private let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
-    deinit {
-        try? group.syncShutdownGracefully()
-    }
-
-    func testIntrospectionTypeQuery() throws {
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query IntrospectionTypeQuery {
-                    __schema {
-                        types {
-                            name
-                        }
+    func testIntrospectionTypeQuery() async throws {
+        let result = try await api.execute(
+            request: """
+            query IntrospectionTypeQuery {
+                __schema {
+                    types {
+                        name
                     }
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(
                 data: [
                     "__schema": [
@@ -92,21 +86,21 @@ class StarWarsIntrospectionTests: XCTestCase {
         )
     }
 
-    func testIntrospectionQueryTypeQuery() throws {
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query IntrospectionQueryTypeQuery {
-                    __schema {
-                        queryType {
-                            name
-                        }
+    func testIntrospectionQueryTypeQuery() async throws {
+        let result = try await api.execute(
+            request: """
+            query IntrospectionQueryTypeQuery {
+                __schema {
+                    queryType {
+                        name
                     }
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(
                 data: [
                     "__schema": [
@@ -119,19 +113,19 @@ class StarWarsIntrospectionTests: XCTestCase {
         )
     }
 
-    func testIntrospectionDroidTypeQuery() throws {
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query IntrospectionDroidTypeQuery {
-                    __type(name: \"Droid\") {
-                        name
-                    }
+    func testIntrospectionDroidTypeQuery() async throws {
+        let result = try await api.execute(
+            request: """
+            query IntrospectionDroidTypeQuery {
+                __type(name: \"Droid\") {
+                    name
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(
                 data: [
                     "__type": [
@@ -142,20 +136,20 @@ class StarWarsIntrospectionTests: XCTestCase {
         )
     }
 
-    func testIntrospectionDroidKindQuery() throws {
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query IntrospectionDroidKindQuery {
-                    __type(name: \"Droid\") {
-                        name
-                        kind
-                    }
+    func testIntrospectionDroidKindQuery() async throws {
+        let result = try await api.execute(
+            request: """
+            query IntrospectionDroidKindQuery {
+                __type(name: \"Droid\") {
+                    name
+                    kind
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(
                 data: [
                     "__type": [
@@ -167,20 +161,20 @@ class StarWarsIntrospectionTests: XCTestCase {
         )
     }
 
-    func testIntrospectionCharacterKindQuery() throws {
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query IntrospectionCharacterKindQuery {
-                    __type(name: \"Character\") {
-                        name
-                        kind
-                    }
+    func testIntrospectionCharacterKindQuery() async throws {
+        let result = try await api.execute(
+            request: """
+            query IntrospectionCharacterKindQuery {
+                __type(name: \"Character\") {
+                    name
+                    kind
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(
                 data: [
                     "__type": [
@@ -192,26 +186,26 @@ class StarWarsIntrospectionTests: XCTestCase {
         )
     }
 
-    func testIntrospectionDroidFieldsQuery() throws {
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query IntrospectionDroidFieldsQuery {
-                    __type(name: \"Droid\") {
+    func testIntrospectionDroidFieldsQuery() async throws {
+        let result = try await api.execute(
+            request: """
+            query IntrospectionDroidFieldsQuery {
+                __type(name: \"Droid\") {
+                    name
+                    fields {
                         name
-                        fields {
+                        type {
                             name
-                            type {
-                                name
-                                kind
-                            }
+                            kind
                         }
                     }
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(
                 data: [
                     "__type": [
@@ -266,30 +260,30 @@ class StarWarsIntrospectionTests: XCTestCase {
         )
     }
 
-    func testIntrospectionDroidNestedFieldsQuery() throws {
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query IntrospectionDroidNestedFieldsQuery {
-                    __type(name: \"Droid\") {
+    func testIntrospectionDroidNestedFieldsQuery() async throws {
+        let result = try await api.execute(
+            request: """
+            query IntrospectionDroidNestedFieldsQuery {
+                __type(name: \"Droid\") {
+                    name
+                    fields {
                         name
-                        fields {
+                        type {
                             name
-                            type {
+                            kind
+                            ofType {
                                 name
                                 kind
-                                ofType {
-                                    name
-                                    kind
-                                }
                             }
                         }
                     }
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(
                 data: [
                     "__type": [
@@ -365,36 +359,36 @@ class StarWarsIntrospectionTests: XCTestCase {
         )
     }
 
-    func testIntrospectionFieldArgsQuery() throws {
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query IntrospectionFieldArgsQuery {
-                    __schema {
-                        queryType {
-                            fields {
+    func testIntrospectionFieldArgsQuery() async throws {
+        let result = try await api.execute(
+            request: """
+            query IntrospectionFieldArgsQuery {
+                __schema {
+                    queryType {
+                        fields {
+                            name
+                            args {
                                 name
-                                args {
+                                description
+                                type {
                                     name
-                                    description
-                                    type {
+                                    kind
+                                    ofType {
                                         name
                                         kind
-                                        ofType {
-                                            name
-                                            kind
-                                        }
                                     }
-                                    defaultValue
-                                 }
-                            }
+                                }
+                                defaultValue
+                                }
                         }
                     }
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(
                 data: [
                     "__schema": [
@@ -477,20 +471,20 @@ class StarWarsIntrospectionTests: XCTestCase {
         )
     }
 
-    func testIntrospectionDroidDescriptionQuery() throws {
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query IntrospectionDroidDescriptionQuery {
-                    __type(name: \"Droid\") {
-                        name
-                        description
-                    }
+    func testIntrospectionDroidDescriptionQuery() async throws {
+        let result = try await api.execute(
+            request: """
+            query IntrospectionDroidDescriptionQuery {
+                __type(name: \"Droid\") {
+                    name
+                    description
                 }
-                """,
-                context: StarWarsContext(),
-                on: group
-            ).wait(),
+            }
+            """,
+            context: StarWarsContext()
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(
                 data: [
                     "__type": [

--- a/Tests/GraphitiTests/UnionTests.swift
+++ b/Tests/GraphitiTests/UnionTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 @testable import Graphiti
 import GraphQL
-import NIO
 import XCTest
 
 class UnionTests: XCTestCase {

--- a/Tests/GraphitiTests/ValidationRulesTests.swift
+++ b/Tests/GraphitiTests/ValidationRulesTests.swift
@@ -1,12 +1,11 @@
 import Foundation
 @testable import Graphiti
 import GraphQL
-import NIO
 import XCTest
 
 class ValidationRulesTests: XCTestCase {
     // Test registering custom validation rules
-    func testRegisteringCustomValidationRule() throws {
+    func testRegisteringCustomValidationRule() async throws {
         struct TestResolver {
             var helloWorld: String { "Hellow World" }
         }
@@ -21,23 +20,20 @@ class ValidationRulesTests: XCTestCase {
             schema: testSchema
         )
 
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-        defer { try? group.syncShutdownGracefully() }
-
-        XCTAssertEqual(
-            try api.execute(
-                request: """
-                query {
-                  __type(name: "Query") {
-                      name
-                      description
-                    }
+        let result = try await api.execute(
+            request: """
+            query {
+                __type(name: "Query") {
+                    name
+                    description
                 }
-                """,
-                context: NoContext(),
-                on: group,
-                validationRules: [NoIntrospectionRule]
-            ).wait(),
+            }
+            """,
+            context: NoContext(),
+            validationRules: [NoIntrospectionRule]
+        )
+        XCTAssertEqual(
+            result,
             GraphQLResult(errors: [
                 .init(
                     message: "GraphQL introspection is not allowed, but the query contained __schema or __type",

--- a/Tests/GraphitiTests/ValidationRulesTests.swift
+++ b/Tests/GraphitiTests/ValidationRulesTests.swift
@@ -44,7 +44,7 @@ class ValidationRulesTests: XCTestCase {
     }
 }
 
-private class TestAPI<Resolver, ContextType>: API {
+private class TestAPI<Resolver: Sendable, ContextType: Sendable>: API {
     public let resolver: Resolver
     public let schema: Schema<Resolver, ContextType>
 

--- a/UsageGuide.md
+++ b/UsageGuide.md
@@ -328,7 +328,7 @@ import GraphQL
 
 let timer: Timer!
 
-struct PersonResolver {
+struct PersonResolver: Sendable {
     func people(context: NoContext, arguments: NoArguments) -> [Person] {
         return characters
     }
@@ -400,7 +400,7 @@ This package supports pagination using the [Relay-based GraphQL Cursor Connectio
 Here's an example using the schema above:
 
 ```swift
-struct Person: Codable, Identifiable {
+struct Person: Codable, Identifiable, Sendable {
     let id: Int
     let name: String
 }
@@ -410,7 +410,7 @@ let characters = [
     Person(id: 2, name: "Bodhi"),
 ]
 
-struct PersonResolver {
+struct PersonResolver: Sendable {
     func people(context: NoContext, arguments: PaginationArguments) throws -> Connection<Person> {
         return try characters.connection(from: arguments)
     }
@@ -524,25 +524,25 @@ extend type User @key(fields: "email") {
 import Foundation
 import Graphiti
 
-struct Product: Codable {
+struct Product: Codable, Sendable {
     let id: String
     let sku: String
     let createdBy: User
 }
 
-struct User: Codable {
+struct User: Codable, Sendable {
     let email: String
     let name: String?
     let totalProductsCreated: Int?
     let yearsOfEmployment: Int
 }
 
-struct ProductContext {
+struct ProductContext: Sendable {
     func getUser(email: String) -> User { ... }
 }
 
-struct ProductResolver {
-    struct UserArguments: Codable {
+struct ProductResolver: Sendable {
+    struct UserArguments: Codable, Sendable {
         let email: String
     }
 


### PR DESCRIPTION
This removes the NIO dependency. It is breaking because it removes all Swift NIO-isms that were present in the public APIs (like EventLoopFuture and EventLoopGroup argument/return types).

Do not merge until https://github.com/GraphQLSwift/GraphQL/pull/166 has been merged and tagged