### PR TITLE
Converts to swift-format

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "indentation" : {
+    "spaces" : 4
+  },
+  "lineBreakBeforeEachArgument": true
+}

--- a/Package.swift
+++ b/Package.swift
@@ -5,16 +5,20 @@ let package = Package(
     name: "Graphiti",
     platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
     products: [
-        .library(name: "Graphiti", targets: ["Graphiti"]),
+        .library(name: "Graphiti", targets: ["Graphiti"])
     ],
     dependencies: [
-        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "4.0.0"),
+        .package(url: "https://github.com/GraphQLSwift/GraphQL.git", from: "4.0.0")
     ],
     targets: [
         .target(name: "Graphiti", dependencies: ["GraphQL"]),
-        .testTarget(name: "GraphitiTests", dependencies: ["Graphiti"], resources: [
-            .copy("FederationTests/GraphQL"),
-        ]),
+        .testTarget(
+            name: "GraphitiTests",
+            dependencies: ["Graphiti"],
+            resources: [
+                .copy("FederationTests/GraphQL")
+            ]
+        ),
     ],
     swiftLanguageVersions: [.v5, .version("6")]
 )

--- a/README.md
+++ b/README.md
@@ -237,11 +237,11 @@ This package supports Swift versions in [alignment with Swift NIO](https://githu
 
 ## Contributing
 
-This repo uses [SwiftFormat](https://github.com/nicklockwood/SwiftFormat), and includes lint checks to enforce these formatting standards.
-To format your code, install `swiftformat` and run:
+This repo uses the standard [swift format](https://github.com/swiftlang/swift-format), and includes lint checks to enforce these formatting standards.
+To format your code, run:
 
 ```bash
-swiftformat .
+swift format --parallel --in-place --recursive ./
 ```
 
 ## License

--- a/Sources/Graphiti/API/API.swift
+++ b/Sources/Graphiti/API/API.swift
@@ -7,8 +7,8 @@ public protocol API {
     var schema: Schema<Resolver, ContextType> { get }
 }
 
-public extension API {
-    func execute(
+extension API {
+    public func execute(
         request: String,
         context: ContextType,
         variables: [String: Map] = [:],
@@ -25,7 +25,7 @@ public extension API {
         )
     }
 
-    func execute(
+    public func execute(
         request: GraphQLRequest,
         context: ContextType,
         validationRules: [@Sendable (ValidationContext) -> Visitor] = []
@@ -39,7 +39,7 @@ public extension API {
         )
     }
 
-    func subscribe(
+    public func subscribe(
         request: String,
         context: ContextType,
         variables: [String: Map] = [:],
@@ -56,7 +56,7 @@ public extension API {
         )
     }
 
-    func subscribe(
+    public func subscribe(
         request: GraphQLRequest,
         context: ContextType,
         validationRules: [@Sendable (ValidationContext) -> Visitor] = []

--- a/Sources/Graphiti/Argument/Argument.swift
+++ b/Sources/Graphiti/Argument/Argument.swift
@@ -26,8 +26,8 @@ public class Argument<ArgumentsType: Decodable, ArgumentType>: ArgumentComponent
     }
 }
 
-public extension Argument {
-    convenience init(
+extension Argument {
+    public convenience init(
         _ name: String,
         at _: KeyPath<ArgumentsType, ArgumentType>
     ) {
@@ -35,8 +35,8 @@ public extension Argument {
     }
 }
 
-public extension Argument where ArgumentType: Encodable {
-    func defaultValue(_ defaultValue: ArgumentType) -> Self {
+extension Argument where ArgumentType: Encodable {
+    public func defaultValue(_ defaultValue: ArgumentType) -> Self {
         self.defaultValue = AnyEncodable(defaultValue)
         return self
     }

--- a/Sources/Graphiti/Argument/ArgumentComponent.swift
+++ b/Sources/Graphiti/Argument/ArgumentComponent.swift
@@ -15,8 +15,8 @@ public class ArgumentComponent<ArgumentsType: Decodable> {
     }
 }
 
-public extension ArgumentComponent {
-    func description(_ description: String) -> Self {
+extension ArgumentComponent {
+    public func description(_ description: String) -> Self {
         self.description = description
         return self
     }

--- a/Sources/Graphiti/Component/Component.swift
+++ b/Sources/Graphiti/Component/Component.swift
@@ -13,8 +13,8 @@ open class Component<Resolver: Sendable, Context: Sendable> {
     func update(typeProvider _: SchemaTypeProvider, coders _: Coders) throws {}
 }
 
-public extension Component {
-    func description(_ description: String) -> Self {
+extension Component {
+    public func description(_ description: String) -> Self {
         self.description = description
         return self
     }

--- a/Sources/Graphiti/Connection/Connection.swift
+++ b/Sources/Graphiti/Connection/Connection.swift
@@ -6,33 +6,36 @@ public struct Connection<Node: Sendable>: Sendable {
     public let pageInfo: PageInfo
 }
 
-public extension Connection where Node: Identifiable, Node.ID: LosslessStringConvertible {
-    static func id(_ cursor: String) -> Node.ID? {
+extension Connection where Node: Identifiable, Node.ID: LosslessStringConvertible {
+    public static func id(_ cursor: String) -> Node.ID? {
         cursor.base64Decoded().flatMap { Node.ID($0) }
     }
 
-    static func cursor(_ node: Node) -> String {
+    public static func cursor(_ node: Node) -> String {
         node.id.description.base64Encoded()!
     }
 }
 
-public extension Sequence where Element: Sendable, Element: Identifiable,
-Element.ID: LosslessStringConvertible {
-    func connection(from arguments: Paginatable) throws -> Connection<Element> {
+extension Sequence
+where
+    Element: Sendable, Element: Identifiable,
+    Element.ID: LosslessStringConvertible
+{
+    public func connection(from arguments: Paginatable) throws -> Connection<Element> {
         try connection(from: arguments, makeCursor: Connection<Element>.cursor)
     }
 
-    func connection(from arguments: ForwardPaginatable) throws -> Connection<Element> {
+    public func connection(from arguments: ForwardPaginatable) throws -> Connection<Element> {
         try connection(from: arguments, makeCursor: Connection<Element>.cursor)
     }
 
-    func connection(from arguments: BackwardPaginatable) throws -> Connection<Element> {
+    public func connection(from arguments: BackwardPaginatable) throws -> Connection<Element> {
         try connection(from: arguments, makeCursor: Connection<Element>.cursor)
     }
 }
 
-public extension Sequence where Element: Sendable {
-    func connection(
+extension Sequence where Element: Sendable {
+    public func connection(
         from arguments: Paginatable,
         makeCursor: @escaping (Element) throws -> String
     ) throws -> Connection<Element> {
@@ -43,7 +46,7 @@ public extension Sequence where Element: Sendable {
         )
     }
 
-    func connection(
+    public func connection(
         from arguments: ForwardPaginatable,
         makeCursor: @escaping (Element) throws -> String
     ) throws -> Connection<Element> {
@@ -54,7 +57,7 @@ public extension Sequence where Element: Sendable {
         )
     }
 
-    func connection(
+    public func connection(
         from arguments: BackwardPaginatable,
         makeCursor: @escaping (Element) throws -> String
     ) throws -> Connection<Element> {
@@ -96,19 +99,16 @@ func slicingCursor<Node>(
 ) -> ArraySlice<Edge<Node>> {
     var edges = ArraySlice(edges)
 
-    if
-        let after = arguments.after,
-        let afterIndex = edges
-            .firstIndex(where: { $0.cursor == after })?
-            .advanced(by: 1)
+    if let after = arguments.after,
+        let afterIndex =
+            edges.firstIndex(where: { $0.cursor == after })?.advanced(by: 1)
     {
         edges = edges[afterIndex...]
     }
 
-    if
-        let before = arguments.before,
-        let beforeIndex = edges
-            .firstIndex(where: { $0.cursor == before })
+    if let before = arguments.before,
+        let beforeIndex =
+            edges.firstIndex(where: { $0.cursor == before })
     {
         edges = edges[..<beforeIndex]
     }

--- a/Sources/Graphiti/Connection/ConnectionType.swift
+++ b/Sources/Graphiti/Connection/ConnectionType.swift
@@ -4,10 +4,7 @@ public final class ConnectionType<
     Resolver: Sendable,
     Context: Sendable,
     ObjectType: Sendable
->: TypeComponent<
-    Resolver,
-    Context
-> {
+>: TypeComponent<Resolver, Context> {
     override func update(typeProvider: SchemaTypeProvider, coders: Coders) throws {
         if !typeProvider.contains(type: PageInfo.self) {
             let pageInfo = Type<Resolver, Context, PageInfo>(PageInfo.self) {
@@ -52,8 +49,8 @@ public final class ConnectionType<
     }
 }
 
-public extension ConnectionType {
-    convenience init(
+extension ConnectionType {
+    public convenience init(
         _ type: ObjectType.Type,
         as name: String? = nil
     ) {

--- a/Sources/Graphiti/Definition/TypeProvider.swift
+++ b/Sources/Graphiti/Definition/TypeProvider.swift
@@ -19,7 +19,8 @@ extension TypeProvider {
 
         guard graphQLNameMap[key] == nil else {
             throw GraphQLError(
-                message: "Duplicate type registration for GraphQL type name \"\(name)\" while trying to register type \(Reflection.name(for: type))"
+                message:
+                    "Duplicate type registration for GraphQL type name \"\(name)\" while trying to register type \(Reflection.name(for: type))"
             )
         }
 
@@ -35,7 +36,8 @@ extension TypeProvider {
 
         guard graphQLTypeMap[key] == nil else {
             throw GraphQLError(
-                message: "Duplicate type registration for GraphQLType \"\(graphQLType.debugDescription)\" while trying to register type \(Reflection.name(for: type))"
+                message:
+                    "Duplicate type registration for GraphQLType \"\(graphQLType.debugDescription)\" while trying to register type \(Reflection.name(for: type))"
             )
         }
 
@@ -50,7 +52,7 @@ extension TypeProvider {
         } else {
             throw GraphQLError(
                 message:
-                "GraphQLType \"\(type)\" is not nullable."
+                    "GraphQLType \"\(type)\" is not nullable."
             )
         }
     }
@@ -83,9 +85,9 @@ extension TypeProvider {
         } catch {
             throw GraphQLError(
                 message:
-                // TODO: Add field type and use "type.field" format.
-                "Cannot use type \"\(type)\" for field \"\(field)\". " +
-                    "Type does not map to a GraphQL type.",
+                    // TODO: Add field type and use "type.field" format.
+                    "Cannot use type \"\(type)\" for field \"\(field)\". "
+                    + "Type does not map to a GraphQL type.",
                 originalError: error
             )
         }
@@ -93,9 +95,9 @@ extension TypeProvider {
         guard let outputType = graphQLType as? GraphQLOutputType else {
             throw GraphQLError(
                 message:
-                // TODO: Add field type and use "type.field" format.
-                "Cannot use type \"\(type)\" for field \"\(field)\". " +
-                    "Mapped GraphQL type is not an output type."
+                    // TODO: Add field type and use "type.field" format.
+                    "Cannot use type \"\(type)\" for field \"\(field)\". "
+                    + "Mapped GraphQL type is not an output type."
             )
         }
 
@@ -110,9 +112,9 @@ extension TypeProvider {
         } catch {
             throw GraphQLError(
                 message:
-                // TODO: Add field type and use "type.field" format.
-                "Cannot use type \"\(type)\" for field \"\(field)\". " +
-                    "Type does not map to a GraphQL type.",
+                    // TODO: Add field type and use "type.field" format.
+                    "Cannot use type \"\(type)\" for field \"\(field)\". "
+                    + "Type does not map to a GraphQL type.",
                 originalError: error
             )
         }
@@ -120,9 +122,9 @@ extension TypeProvider {
         guard let inputType = graphQLType as? GraphQLInputType else {
             throw GraphQLError(
                 message:
-                // TODO: Add field type and use "type.field" format.
-                "Cannot use type \"\(type)\" for field \"\(field)\". " +
-                    "Mapped GraphQL type is not an input type."
+                    // TODO: Add field type and use "type.field" format.
+                    "Cannot use type \"\(type)\" for field \"\(field)\". "
+                    + "Mapped GraphQL type is not an input type."
             )
         }
 
@@ -137,8 +139,8 @@ extension TypeProvider {
         } catch {
             throw GraphQLError(
                 message:
-                "Cannot use type \"\(type)\" as named type. " +
-                    "Type does not map to a GraphQL type.",
+                    "Cannot use type \"\(type)\" as named type. "
+                    + "Type does not map to a GraphQL type.",
                 originalError: error
             )
         }
@@ -146,8 +148,8 @@ extension TypeProvider {
         guard let namedType = GraphQL.getNamedType(type: graphQLType) else {
             throw GraphQLError(
                 message:
-                "Cannot use type \"\(type)\" as named type. " +
-                    "Mapped GraphQL type is not a named type."
+                    "Cannot use type \"\(type)\" as named type. "
+                    + "Mapped GraphQL type is not a named type."
             )
         }
 
@@ -159,9 +161,8 @@ extension TypeProvider {
         guard Reflection.isProtocol(type: type) else {
             throw GraphQLError(
                 message:
-                // TODO: Add more information of where the error happened.
-                "Cannot use type \"\(type)\" as interface. " +
-                    "Type is not a protocol."
+                    // TODO: Add more information of where the error happened.
+                    "Cannot use type \"\(type)\" as interface. " + "Type is not a protocol."
             )
         }
 
@@ -172,9 +173,9 @@ extension TypeProvider {
         } catch {
             throw GraphQLError(
                 message:
-                // TODO: Add more information of where the error happened.
-                "Cannot use type \"\(type)\" as interface. " +
-                    "Type does not map to a GraphQL type.",
+                    // TODO: Add more information of where the error happened.
+                    "Cannot use type \"\(type)\" as interface. "
+                    + "Type does not map to a GraphQL type.",
                 originalError: error
             )
         }
@@ -182,18 +183,18 @@ extension TypeProvider {
         guard let nonNull = graphQLType as? GraphQLNonNull else {
             throw GraphQLError(
                 message:
-                // TODO: Add more information of where the error happened.
-                "Cannot use type \"\(type)\" as interface. " +
-                    "Mapped GraphQL type is nullable."
+                    // TODO: Add more information of where the error happened.
+                    "Cannot use type \"\(type)\" as interface. "
+                    + "Mapped GraphQL type is nullable."
             )
         }
 
         guard let interfaceType = nonNull.ofType as? GraphQLInterfaceType else {
             throw GraphQLError(
                 message:
-                // TODO: Add more information of where the error happened.
-                "Cannot use type \"\(type)\" as interface. " +
-                    "Mapped GraphQL type is not an interface type."
+                    // TODO: Add more information of where the error happened.
+                    "Cannot use type \"\(type)\" as interface. "
+                    + "Mapped GraphQL type is not an interface type."
             )
         }
 
@@ -208,9 +209,9 @@ extension TypeProvider {
         } catch {
             throw GraphQLError(
                 message:
-                // TODO: Add more information of where the error happened.
-                "Cannot use type \"\(type)\" as object. " +
-                    "Type does not map to a GraphQL type.",
+                    // TODO: Add more information of where the error happened.
+                    "Cannot use type \"\(type)\" as object. "
+                    + "Type does not map to a GraphQL type.",
                 originalError: error
             )
         }
@@ -218,18 +219,17 @@ extension TypeProvider {
         guard let nonNull = graphQLType as? GraphQLNonNull else {
             throw GraphQLError(
                 message:
-                // TODO: Add more information of where the error happened.
-                "Cannot use type \"\(type)\" as object. " +
-                    "Mapped GraphQL type is nullable."
+                    // TODO: Add more information of where the error happened.
+                    "Cannot use type \"\(type)\" as object. " + "Mapped GraphQL type is nullable."
             )
         }
 
         guard let objectType = nonNull.ofType as? GraphQLObjectType else {
             throw GraphQLError(
                 message:
-                // TODO: Add more information of where the error happened.
-                "Cannot use type \"\(type)\" as object. " +
-                    "Mapped GraphQL type is not an object type."
+                    // TODO: Add more information of where the error happened.
+                    "Cannot use type \"\(type)\" as object. "
+                    + "Mapped GraphQL type is not an object type."
             )
         }
 

--- a/Sources/Graphiti/Enum/Enum.swift
+++ b/Sources/Graphiti/Enum/Enum.swift
@@ -4,10 +4,7 @@ public final class Enum<
     Resolver: Sendable,
     Context: Sendable,
     EnumType: Encodable & RawRepresentable
->: TypeComponent<
-    Resolver,
-    Context
-> where EnumType.RawValue == String {
+>: TypeComponent<Resolver, Context> where EnumType.RawValue == String {
     private let values: [Value<EnumType>]
 
     override func update(typeProvider: SchemaTypeProvider, coders _: Coders) throws {
@@ -39,8 +36,8 @@ public final class Enum<
     }
 }
 
-public extension Enum {
-    convenience init(
+extension Enum {
+    public convenience init(
         _ type: EnumType.Type,
         as name: String? = nil,
         @ValueBuilder<EnumType> _ values: () -> Value<EnumType>
@@ -48,7 +45,7 @@ public extension Enum {
         self.init(type: type, name: name, values: [values()])
     }
 
-    convenience init(
+    public convenience init(
         _ type: EnumType.Type,
         as name: String? = nil,
         @ValueBuilder<EnumType> _ values: () -> [Value<EnumType>]

--- a/Sources/Graphiti/Federation/Key/Key.swift
+++ b/Sources/Graphiti/Federation/Key/Key.swift
@@ -5,11 +5,7 @@ public class Key<
     Resolver: Sendable,
     Context: Sendable,
     Arguments: Codable & Sendable
->: KeyComponent<
-    ObjectType,
-    Resolver,
-    Context
->, @unchecked Sendable {
+>: KeyComponent<ObjectType, Resolver, Context>, @unchecked Sendable {
     let arguments: [ArgumentComponent<Arguments>]
     let resolve: AsyncResolve<Resolver, Context, Arguments, ObjectType?>
 

--- a/Sources/Graphiti/Federation/Key/Type+Key.swift
+++ b/Sources/Graphiti/Federation/Key/Type+Key.swift
@@ -1,6 +1,6 @@
 import GraphQL
 
-public extension Type {
+extension Type {
     /// Define and add the federated key to this type.
     ///
     /// For more information, see https://www.apollographql.com/docs/federation/entities
@@ -9,7 +9,7 @@ public extension Type {
     ///   - _:  The key value. The name of this argument must match a Type field.
     /// - Returns: Self for chaining.
     @discardableResult
-    func key<Arguments: Codable & Sendable>(
+    public func key<Arguments: Codable & Sendable>(
         at function: @escaping AsyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) -> Self {
@@ -25,7 +25,7 @@ public extension Type {
     ///   - _:  The key values. The names of these arguments must match Type fields.
     /// - Returns: Self for chaining.
     @discardableResult
-    func key<Arguments: Codable & Sendable>(
+    public func key<Arguments: Codable & Sendable>(
         at function: @escaping AsyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
             -> [ArgumentComponent<Arguments>] = { [] }
@@ -42,7 +42,7 @@ public extension Type {
     ///   - _:  The key value. The name of this argument must match a Type field.
     /// - Returns: Self for chaining.
     @discardableResult
-    func key<Arguments: Codable & Sendable>(
+    public func key<Arguments: Codable & Sendable>(
         at function: @escaping SyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
             -> [ArgumentComponent<Arguments>] = { [] }
@@ -59,7 +59,7 @@ public extension Type {
     ///   - _:  The key values. The names of these arguments must match Type fields.
     /// - Returns: Self for chaining.
     @discardableResult
-    func key<Arguments: Codable & Sendable>(
+    public func key<Arguments: Codable & Sendable>(
         at function: @escaping SyncResolve<Resolver, Context, Arguments, ObjectType?>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) -> Self {

--- a/Sources/Graphiti/Federation/Queries.swift
+++ b/Sources/Graphiti/Federation/Queries.swift
@@ -21,7 +21,7 @@ func entitiesQuery(
         args: [
             "representations": GraphQLArgument(
                 type: GraphQLNonNull(GraphQLList(GraphQLNonNull(anyType)))
-            ),
+            )
         ],
         resolve: { source, args, context, info in
             let arguments = try coders.decoder.decode(EntityArguments.self, from: args)

--- a/Sources/Graphiti/Federation/Service.swift
+++ b/Sources/Graphiti/Federation/Service.swift
@@ -8,6 +8,6 @@ let serviceType = try! GraphQLObjectType(
     name: "_Service",
     description: "Federation service object",
     fields: [
-        "sdl": GraphQLField(type: GraphQLString),
+        "sdl": GraphQLField(type: GraphQLString)
     ]
 )

--- a/Sources/Graphiti/Field/Field/Field.swift
+++ b/Sources/Graphiti/Field/Field/Field.swift
@@ -5,10 +5,7 @@ public class Field<
     Context: Sendable,
     FieldType: Sendable,
     Arguments: Decodable & Sendable
->: FieldComponent<
-    ObjectType,
-    Context
-> {
+>: FieldComponent<ObjectType, Context> {
     let name: String
     let arguments: [ArgumentComponent<Arguments>]
     let resolve: AsyncResolve<ObjectType, Context, Arguments, (any Sendable)?>
@@ -26,13 +23,15 @@ public class Field<
             resolve: { source, arguments, context, _ in
                 guard let s = source as? ObjectType else {
                     throw GraphQLError(
-                        message: "Expected source type \(ObjectType.self) but got \(type(of: source))"
+                        message:
+                            "Expected source type \(ObjectType.self) but got \(type(of: source))"
                     )
                 }
 
                 guard let c = context as? Context else {
                     throw GraphQLError(
-                        message: "Expected context type \(Context.self) but got \(type(of: context))"
+                        message:
+                            "Expected context type \(Context.self) but got \(type(of: context))"
                     )
                 }
 
@@ -95,8 +94,8 @@ public class Field<
 
 // MARK: AsyncResolve Initializers
 
-public extension Field {
-    convenience init(
+extension Field {
+    public convenience init(
         _ name: String,
         at function: @escaping AsyncResolve<ObjectType, Context, Arguments, FieldType>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
@@ -104,7 +103,7 @@ public extension Field {
         self.init(name: name, arguments: [argument()], asyncResolve: function)
     }
 
-    convenience init(
+    public convenience init(
         _ name: String,
         at function: @escaping AsyncResolve<ObjectType, Context, Arguments, FieldType>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
@@ -114,8 +113,8 @@ public extension Field {
     }
 }
 
-public extension Field {
-    convenience init(
+extension Field {
+    public convenience init(
         _ name: String,
         at function: @escaping SyncResolve<ObjectType, Context, Arguments, FieldType>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
@@ -123,7 +122,7 @@ public extension Field {
         self.init(name: name, arguments: [argument()], syncResolve: function)
     }
 
-    convenience init(
+    public convenience init(
         _ name: String,
         at function: @escaping SyncResolve<ObjectType, Context, Arguments, FieldType>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
@@ -135,8 +134,8 @@ public extension Field {
 
 // MARK: Keypath Initializers
 
-public extension Field where Arguments == NoArguments {
-    convenience init(
+extension Field where Arguments == NoArguments {
+    public convenience init(
         _ name: String,
         at keyPath: KeyPath<ObjectType, FieldType>
     ) {

--- a/Sources/Graphiti/Field/Field/FieldComponent.swift
+++ b/Sources/Graphiti/Field/Field/FieldComponent.swift
@@ -9,13 +9,13 @@ public class FieldComponent<ObjectType, Context> {
     }
 }
 
-public extension FieldComponent {
-    func description(_ description: String) -> Self {
+extension FieldComponent {
+    public func description(_ description: String) -> Self {
         self.description = description
         return self
     }
 
-    func deprecationReason(_ deprecationReason: String) -> Self {
+    public func deprecationReason(_ deprecationReason: String) -> Self {
         self.deprecationReason = deprecationReason
         return self
     }

--- a/Sources/Graphiti/Field/Resolve/AsyncResolve.swift
+++ b/Sources/Graphiti/Field/Resolve/AsyncResolve.swift
@@ -1,7 +1,7 @@
-
-public typealias AsyncResolve<ObjectType, Context, Arguments, ResolveType> = @Sendable (
-    _ object: ObjectType
-) -> (
-    _ context: Context,
-    _ arguments: Arguments
-) async throws -> ResolveType
+public typealias AsyncResolve<ObjectType, Context, Arguments, ResolveType> =
+    @Sendable (
+        _ object: ObjectType
+    ) -> (
+        _ context: Context,
+        _ arguments: Arguments
+    ) async throws -> ResolveType

--- a/Sources/Graphiti/Field/Resolve/SyncResolve.swift
+++ b/Sources/Graphiti/Field/Resolve/SyncResolve.swift
@@ -1,6 +1,7 @@
-public typealias SyncResolve<ObjectType, Context, Arguments, ResolveType> = @Sendable (
-    _ object: ObjectType
-) -> (
-    _ context: Context,
-    _ arguments: Arguments
-) throws -> ResolveType
+public typealias SyncResolve<ObjectType, Context, Arguments, ResolveType> =
+    @Sendable (
+        _ object: ObjectType
+    ) -> (
+        _ context: Context,
+        _ arguments: Arguments
+    ) throws -> ResolveType

--- a/Sources/Graphiti/Input/Input.swift
+++ b/Sources/Graphiti/Input/Input.swift
@@ -4,10 +4,7 @@ public final class Input<
     Resolver: Sendable,
     Context: Sendable,
     InputObjectType
->: TypeComponent<
-    Resolver,
-    Context
-> {
+>: TypeComponent<Resolver, Context> {
     let isOneOf: Bool
     let fields: [InputFieldComponent<InputObjectType, Context>]
 
@@ -50,8 +47,8 @@ public final class Input<
     }
 }
 
-public extension Input {
-    convenience init(
+extension Input {
+    public convenience init(
         _ type: InputObjectType.Type,
         as name: String? = nil,
         isOneOf: Bool = false,
@@ -61,7 +58,7 @@ public extension Input {
         self.init(type: type, name: name, isOneOf: isOneOf, fields: [fields()])
     }
 
-    convenience init(
+    public convenience init(
         _ type: InputObjectType.Type,
         as name: String? = nil,
         isOneOf: Bool = false,

--- a/Sources/Graphiti/InputField/InputField.swift
+++ b/Sources/Graphiti/InputField/InputField.swift
@@ -4,10 +4,7 @@ public class InputField<
     InputObjectType,
     Context: Sendable,
     FieldType
->: InputFieldComponent<
-    InputObjectType,
-    Context
-> {
+>: InputFieldComponent<InputObjectType, Context> {
     let name: String
     var defaultValue: AnyEncodable?
 
@@ -30,8 +27,8 @@ public class InputField<
     }
 }
 
-public extension InputField {
-    convenience init(
+extension InputField {
+    public convenience init(
         _ name: String,
         at _: KeyPath<InputObjectType, FieldType>
     ) {
@@ -39,8 +36,8 @@ public extension InputField {
     }
 }
 
-public extension InputField where FieldType: Encodable {
-    func defaultValue(_ defaultValue: FieldType) -> Self {
+extension InputField where FieldType: Encodable {
+    public func defaultValue(_ defaultValue: FieldType) -> Self {
         self.defaultValue = AnyEncodable(defaultValue)
         return self
     }

--- a/Sources/Graphiti/InputField/InputFieldComponent.swift
+++ b/Sources/Graphiti/InputField/InputFieldComponent.swift
@@ -8,8 +8,8 @@ public class InputFieldComponent<InputObjectType, Context> {
     }
 }
 
-public extension InputFieldComponent {
-    func description(_ description: String) -> Self {
+extension InputFieldComponent {
+    public func description(_ description: String) -> Self {
         self.description = description
         return self
     }

--- a/Sources/Graphiti/Interface/Interface.swift
+++ b/Sources/Graphiti/Interface/Interface.swift
@@ -4,10 +4,7 @@ public final class Interface<
     Resolver: Sendable,
     Context: Sendable,
     InterfaceType
->: TypeComponent<
-    Resolver,
-    Context
-> {
+>: TypeComponent<Resolver, Context> {
     let fields: [FieldComponent<InterfaceType, Context>]
 
     override func update(typeProvider: SchemaTypeProvider, coders: Coders) throws {
@@ -47,8 +44,8 @@ public final class Interface<
     }
 }
 
-public extension Interface {
-    convenience init(
+extension Interface {
+    public convenience init(
         _ type: InterfaceType.Type,
         as name: String? = nil,
         @FieldComponentBuilder<InterfaceType, Context> _ fields: ()
@@ -61,7 +58,7 @@ public extension Interface {
         )
     }
 
-    convenience init(
+    public convenience init(
         _ type: InterfaceType.Type,
         as name: String? = nil,
         @FieldComponentBuilder<InterfaceType, Context> _ fields: ()

--- a/Sources/Graphiti/Mutation/Mutation.swift
+++ b/Sources/Graphiti/Mutation/Mutation.swift
@@ -41,15 +41,15 @@ public final class Mutation<Resolver: Sendable, Context: Sendable>: Component<Re
     }
 }
 
-public extension Mutation {
-    convenience init(
+extension Mutation {
+    public convenience init(
         as name: String = "Mutation",
         @FieldComponentBuilder<Resolver, Context> _ fields: () -> FieldComponent<Resolver, Context>
     ) {
         self.init(name: name, fields: [fields()])
     }
 
-    convenience init(
+    public convenience init(
         as name: String = "Mutation",
         @FieldComponentBuilder<Resolver, Context> _ fields: ()
             -> [FieldComponent<Resolver, Context>]

--- a/Sources/Graphiti/Query/Query.swift
+++ b/Sources/Graphiti/Query/Query.swift
@@ -66,15 +66,15 @@ public final class Query<Resolver: Sendable, Context: Sendable>: Component<Resol
     }
 }
 
-public extension Query {
-    convenience init(
+extension Query {
+    public convenience init(
         as name: String = "Query",
         @FieldComponentBuilder<Resolver, Context> _ fields: () -> FieldComponent<Resolver, Context>
     ) {
         self.init(name: name, fields: [fields()])
     }
 
-    convenience init(
+    public convenience init(
         as name: String = "Query",
         @FieldComponentBuilder<Resolver, Context> _ fields: ()
             -> [FieldComponent<Resolver, Context>]

--- a/Sources/Graphiti/Scalar/Scalar.swift
+++ b/Sources/Graphiti/Scalar/Scalar.swift
@@ -94,8 +94,8 @@ open class Scalar<
     }
 }
 
-public extension Scalar {
-    convenience init(
+extension Scalar {
+    public convenience init(
         _ type: ScalarType.Type,
         as name: String? = nil,
         specifiedBy: String? = nil,
@@ -116,48 +116,36 @@ public extension Scalar {
 
 extension GraphQL.Value {
     var map: Map {
-        if
-            let value = self as? BooleanValue
-        {
+        if let value = self as? BooleanValue {
             return .bool(value.value)
         }
 
-        if
-            let value = self as? IntValue,
+        if let value = self as? IntValue,
             let int = Int(value.value)
         {
             return .int(int)
         }
 
-        if
-            let value = self as? FloatValue,
+        if let value = self as? FloatValue,
             let double = Double(value.value)
         {
             return .double(double)
         }
 
-        if
-            let value = self as? StringValue
-        {
+        if let value = self as? StringValue {
             return .string(value.value)
         }
 
-        if
-            let value = self as? EnumValue
-        {
+        if let value = self as? EnumValue {
             return .string(value.value)
         }
 
-        if
-            let value = self as? ListValue
-        {
+        if let value = self as? ListValue {
             let array = value.values.map { $0.map }
             return .array(array)
         }
 
-        if
-            let value = self as? ObjectValue
-        {
+        if let value = self as? ObjectValue {
             let dictionary: OrderedDictionary<String, Map> = value.fields
                 .reduce(into: [:]) { result, field in
                     result[field.name.value] = field.value.map

--- a/Sources/Graphiti/Schema/Schema.swift
+++ b/Sources/Graphiti/Schema/Schema.swift
@@ -35,8 +35,8 @@ public final class Schema<Resolver: Sendable, Context: Sendable>: Sendable {
     }
 }
 
-public extension Schema {
-    convenience init(
+extension Schema {
+    public convenience init(
         coders: Coders = Coders(),
         federatedSDL: String? = nil,
         @ComponentBuilder<Resolver, Context> _ components: () -> Component<Resolver, Context>
@@ -48,7 +48,7 @@ public extension Schema {
         )
     }
 
-    convenience init(
+    public convenience init(
         coders: Coders = Coders(),
         federatedSDL: String? = nil,
         @ComponentBuilder<Resolver, Context> _ components: () -> [Component<Resolver, Context>]
@@ -60,7 +60,7 @@ public extension Schema {
         )
     }
 
-    func execute(
+    public func execute(
         request: String,
         resolver: Resolver,
         context: Context,
@@ -79,7 +79,7 @@ public extension Schema {
         )
     }
 
-    func subscribe(
+    public func subscribe(
         request: String,
         resolver: Resolver,
         context: Context,

--- a/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
+++ b/Sources/Graphiti/SchemaBuilders/PartialSchema.swift
@@ -52,11 +52,11 @@ open class PartialSchema<Resolver: Sendable, Context: Sendable> {
     }
 }
 
-public extension Schema {
+extension Schema {
     /// Create a schema from partial schemas
     /// - Parameter partials: Partial schemas that declare types, query, mutation, and/or subscription definiton
     /// - Returns: A compiled schema will all definitions given from the partial schemas
-    static func create(
+    public static func create(
         from partials: [PartialSchema<Resolver, Context>]
     ) throws -> Schema<Resolver, Context> {
         try SchemaBuilder(Resolver.self, Context.self)

--- a/Sources/Graphiti/Subscription/SubscribeField.swift
+++ b/Sources/Graphiti/Subscription/SubscribeField.swift
@@ -29,13 +29,15 @@ public class SubscriptionField<
             resolve: { source, arguments, context, _ in
                 guard let _source = source as? SourceEventType else {
                     throw GraphQLError(
-                        message: "Expected source type \(SourceEventType.self) but got \(type(of: source))"
+                        message:
+                            "Expected source type \(SourceEventType.self) but got \(type(of: source))"
                     )
                 }
 
                 guard let _context = context as? Context else {
                     throw GraphQLError(
-                        message: "Expected context type \(Context.self) but got \(type(of: context))"
+                        message:
+                            "Expected context type \(Context.self) but got \(type(of: context))"
                     )
                 }
 
@@ -45,13 +47,15 @@ public class SubscriptionField<
             subscribe: { source, arguments, context, _ in
                 guard let _source = source as? ObjectType else {
                     throw GraphQLError(
-                        message: "Expected source type \(ObjectType.self) but got \(type(of: source))"
+                        message:
+                            "Expected source type \(ObjectType.self) but got \(type(of: source))"
                     )
                 }
 
                 guard let _context = context as? Context else {
                     throw GraphQLError(
-                        message: "Expected context type \(Context.self) but got \(type(of: context))"
+                        message:
+                            "Expected context type \(Context.self) but got \(type(of: context))"
                     )
                 }
 
@@ -78,12 +82,7 @@ public class SubscriptionField<
         name: String,
         arguments: [ArgumentComponent<Arguments>],
         resolve: @escaping AsyncResolve<SourceEventType, Context, Arguments, (any Sendable)?>,
-        subscribe: @escaping AsyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >
+        subscribe: @escaping AsyncResolve<ObjectType, Context, Arguments, SubSequence>
     ) {
         self.name = name
         self.arguments = arguments
@@ -95,12 +94,7 @@ public class SubscriptionField<
         name: String,
         arguments: [ArgumentComponent<Arguments>],
         asyncResolve: @escaping AsyncResolve<SourceEventType, Context, Arguments, ResolveType>,
-        asyncSubscribe: @escaping AsyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >
+        asyncSubscribe: @escaping AsyncResolve<ObjectType, Context, Arguments, SubSequence>
     ) {
         let resolve: AsyncResolve<SourceEventType, Context, Arguments, (any Sendable)?> = { type in
             { context, arguments in
@@ -114,23 +108,19 @@ public class SubscriptionField<
         name: String,
         arguments: [ArgumentComponent<Arguments>],
         as _: FieldType.Type,
-        asyncSubscribe: @escaping AsyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >
+        asyncSubscribe: @escaping AsyncResolve<ObjectType, Context, Arguments, SubSequence>
     ) {
-        let resolve: AsyncResolve<
-            SourceEventType,
-            Context,
-            Arguments,
-            (any Sendable)?
-        > = { source in
-            { _, _ in
-                source
+        let resolve:
+            AsyncResolve<
+                SourceEventType,
+                Context,
+                Arguments,
+                (any Sendable)?
+            > = { source in
+                { _, _ in
+                    source
+                }
             }
-        }
         self.init(name: name, arguments: arguments, resolve: resolve, subscribe: asyncSubscribe)
     }
 
@@ -138,12 +128,7 @@ public class SubscriptionField<
         name: String,
         arguments: [ArgumentComponent<Arguments>],
         syncResolve: @escaping SyncResolve<SourceEventType, Context, Arguments, ResolveType>,
-        syncSubscribe: @escaping SyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >
+        syncSubscribe: @escaping SyncResolve<ObjectType, Context, Arguments, SubSequence>
     ) {
         let asyncResolve: AsyncResolve<SourceEventType, Context, Arguments, ResolveType> = { type in
             { context, arguments in
@@ -151,12 +136,7 @@ public class SubscriptionField<
             }
         }
 
-        let asyncSubscribe: AsyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        > = { type in
+        let asyncSubscribe: AsyncResolve<ObjectType, Context, Arguments, SubSequence> = { type in
             { context, arguments in
                 try syncSubscribe(type)(context, arguments)
             }
@@ -173,39 +153,30 @@ public class SubscriptionField<
         name: String,
         arguments: [ArgumentComponent<Arguments>],
         as: FieldType.Type,
-        syncSubscribe: @escaping SyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >
+        syncSubscribe: @escaping SyncResolve<ObjectType, Context, Arguments, SubSequence>
     ) {
-        let asyncSubscribe: AsyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        > = { type in
-            { context, arguments in
-                try syncSubscribe(type)(context, arguments)
+        let asyncSubscribe:
+            AsyncResolve<
+                ObjectType,
+                Context,
+                Arguments,
+                SubSequence
+            > = { type in
+                { context, arguments in
+                    try syncSubscribe(type)(context, arguments)
+                }
             }
-        }
         self.init(name: name, arguments: arguments, as: `as`, asyncSubscribe: asyncSubscribe)
     }
 }
 
 // MARK: AsyncResolve Initializers
 
-public extension SubscriptionField {
-    convenience init(
+extension SubscriptionField {
+    public convenience init(
         _ name: String,
         at function: @escaping AsyncResolve<SourceEventType, Context, Arguments, FieldType>,
-        atSub subFunc: @escaping AsyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >,
+        atSub subFunc: @escaping AsyncResolve<ObjectType, Context, Arguments, SubSequence>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) {
         self.init(
@@ -216,15 +187,10 @@ public extension SubscriptionField {
         )
     }
 
-    convenience init(
+    public convenience init(
         _ name: String,
         at function: @escaping AsyncResolve<SourceEventType, Context, Arguments, FieldType>,
-        atSub subFunc: @escaping AsyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >,
+        atSub subFunc: @escaping AsyncResolve<ObjectType, Context, Arguments, SubSequence>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
             -> [ArgumentComponent<Arguments>] = { [] }
     ) {
@@ -237,45 +203,30 @@ public extension SubscriptionField {
     }
 }
 
-public extension SubscriptionField {
-    convenience init(
+extension SubscriptionField {
+    public convenience init(
         _ name: String,
         as: FieldType.Type,
-        atSub subFunc: @escaping AsyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >,
+        atSub subFunc: @escaping AsyncResolve<ObjectType, Context, Arguments, SubSequence>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) {
         self.init(name: name, arguments: [argument()], as: `as`, asyncSubscribe: subFunc)
     }
 
-    convenience init(
+    public convenience init(
         _ name: String,
         as: FieldType.Type,
-        atSub subFunc: @escaping AsyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >,
+        atSub subFunc: @escaping AsyncResolve<ObjectType, Context, Arguments, SubSequence>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
             -> [ArgumentComponent<Arguments>] = { [] }
     ) {
         self.init(name: name, arguments: arguments(), as: `as`, asyncSubscribe: subFunc)
     }
 
-    convenience init<ResolveType: Sendable>(
+    public convenience init<ResolveType: Sendable>(
         _ name: String,
         at function: @escaping AsyncResolve<SourceEventType, Context, Arguments, ResolveType>,
-        atSub subFunc: @escaping AsyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >,
+        atSub subFunc: @escaping AsyncResolve<ObjectType, Context, Arguments, SubSequence>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) {
         self.init(
@@ -286,15 +237,10 @@ public extension SubscriptionField {
         )
     }
 
-    convenience init<ResolveType: Sendable>(
+    public convenience init<ResolveType: Sendable>(
         _ name: String,
         at function: @escaping AsyncResolve<SourceEventType, Context, Arguments, ResolveType>,
-        atSub subFunc: @escaping AsyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >,
+        atSub subFunc: @escaping AsyncResolve<ObjectType, Context, Arguments, SubSequence>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
             -> [ArgumentComponent<Arguments>] = { [] }
     ) {
@@ -307,16 +253,11 @@ public extension SubscriptionField {
     }
 }
 
-public extension SubscriptionField {
-    convenience init(
+extension SubscriptionField {
+    public convenience init(
         _ name: String,
         at function: @escaping SyncResolve<SourceEventType, Context, Arguments, FieldType>,
-        atSub subFunc: @escaping SyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >,
+        atSub subFunc: @escaping SyncResolve<ObjectType, Context, Arguments, SubSequence>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) {
         self.init(
@@ -327,15 +268,10 @@ public extension SubscriptionField {
         )
     }
 
-    convenience init(
+    public convenience init(
         _ name: String,
         at function: @escaping SyncResolve<SourceEventType, Context, Arguments, FieldType>,
-        atSub subFunc: @escaping SyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >,
+        atSub subFunc: @escaping SyncResolve<ObjectType, Context, Arguments, SubSequence>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
             -> [ArgumentComponent<Arguments>] = { [] }
     ) {
@@ -343,32 +279,22 @@ public extension SubscriptionField {
     }
 }
 
-public extension SubscriptionField {
+extension SubscriptionField {
     @_disfavoredOverload
-    convenience init(
+    public convenience init(
         _ name: String,
         as: FieldType.Type,
-        atSub subFunc: @escaping SyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >,
+        atSub subFunc: @escaping SyncResolve<ObjectType, Context, Arguments, SubSequence>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) {
         self.init(name: name, arguments: [argument()], as: `as`, syncSubscribe: subFunc)
     }
 
     @_disfavoredOverload
-    convenience init(
+    public convenience init(
         _ name: String,
         as: FieldType.Type,
-        atSub subFunc: @escaping SyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >,
+        atSub subFunc: @escaping SyncResolve<ObjectType, Context, Arguments, SubSequence>,
         @ArgumentComponentBuilder<Arguments> _ arguments: ()
             -> [ArgumentComponent<Arguments>] = { [] }
     ) {
@@ -376,16 +302,11 @@ public extension SubscriptionField {
     }
 
     @_disfavoredOverload
-    convenience init<ResolveType: Sendable>(
+    public convenience init<ResolveType: Sendable>(
         _ name: String,
         at function: @escaping SyncResolve<SourceEventType, Context, Arguments, ResolveType>,
         as _: FieldType.Type,
-        atSub subFunc: @escaping SyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >,
+        atSub subFunc: @escaping SyncResolve<ObjectType, Context, Arguments, SubSequence>,
         @ArgumentComponentBuilder<Arguments> _ argument: () -> ArgumentComponent<Arguments>
     ) {
         self.init(
@@ -397,18 +318,14 @@ public extension SubscriptionField {
     }
 
     @_disfavoredOverload
-    convenience init<ResolveType: Sendable>(
+    public convenience init<ResolveType: Sendable>(
         _ name: String,
         at function: @escaping SyncResolve<SourceEventType, Context, Arguments, ResolveType>,
         as _: FieldType.Type,
-        atSub subFunc: @escaping SyncResolve<
-            ObjectType,
-            Context,
-            Arguments,
-            SubSequence
-        >,
-        @ArgumentComponentBuilder<Arguments> _ arguments: ()
-            -> [ArgumentComponent<Arguments>] = { [] }
+        atSub subFunc: @escaping SyncResolve<ObjectType, Context, Arguments, SubSequence>,
+        @ArgumentComponentBuilder<Arguments> _ arguments: () -> [ArgumentComponent<Arguments>] = {
+            []
+        }
     ) {
         self.init(name: name, arguments: arguments(), syncResolve: function, syncSubscribe: subFunc)
     }

--- a/Sources/Graphiti/Subscription/SubscribeResolve.swift
+++ b/Sources/Graphiti/Subscription/SubscribeResolve.swift
@@ -1,4 +1,3 @@
-
 public typealias SubscribeResolve<ObjectType, Context, Arguments, ResolveType> = (
     _ object: ObjectType
 ) -> (

--- a/Sources/Graphiti/Subscription/Subscription.swift
+++ b/Sources/Graphiti/Subscription/Subscription.swift
@@ -3,10 +3,7 @@ import GraphQL
 public final class Subscription<
     Resolver: Sendable,
     Context: Sendable
->: Component<
-    Resolver,
-    Context
-> {
+>: Component<Resolver, Context> {
     let fields: [FieldComponent<Resolver, Context>]
 
     let isTypeOf: GraphQLIsTypeOf = { source, _ in
@@ -47,15 +44,15 @@ public final class Subscription<
     }
 }
 
-public extension Subscription {
-    convenience init(
+extension Subscription {
+    public convenience init(
         as name: String = "Subscription",
         @FieldComponentBuilder<Resolver, Context> _ fields: () -> FieldComponent<Resolver, Context>
     ) {
         self.init(name: name, fields: [fields()])
     }
 
-    convenience init(
+    public convenience init(
         as name: String = "Subscription",
         @FieldComponentBuilder<Resolver, Context> _ fields: ()
             -> [FieldComponent<Resolver, Context>]

--- a/Sources/Graphiti/Type/Type.swift
+++ b/Sources/Graphiti/Type/Type.swift
@@ -4,10 +4,7 @@ public final class Type<
     Resolver: Sendable,
     Context: Sendable,
     ObjectType: Sendable
->: TypeComponent<
-    Resolver,
-    Context
-> {
+>: TypeComponent<Resolver, Context> {
     let interfaces: [Any.Type]
     var keys: [KeyComponent<ObjectType, Resolver, Context>]
     let fields: [FieldComponent<ObjectType, Context>]
@@ -44,13 +41,15 @@ public final class Type<
             let resolve: GraphQLFieldResolve = { source, args, context, _ in
                 guard let s = source as? Resolver else {
                     throw GraphQLError(
-                        message: "Expected source type \(ObjectType.self) but got \(type(of: source))"
+                        message:
+                            "Expected source type \(ObjectType.self) but got \(type(of: source))"
                     )
                 }
 
                 guard let c = context as? Context else {
                     throw GraphQLError(
-                        message: "Expected context type \(Context.self) but got \(type(of: context))"
+                        message:
+                            "Expected context type \(Context.self) but got \(type(of: context))"
                     )
                 }
 
@@ -104,8 +103,8 @@ public final class Type<
     }
 }
 
-public extension Type {
-    convenience init(
+extension Type {
+    public convenience init(
         _ type: ObjectType.Type,
         as name: String? = nil,
         interfaces: [Any.Type] = [],
@@ -121,7 +120,7 @@ public extension Type {
         )
     }
 
-    convenience init(
+    public convenience init(
         _ type: ObjectType.Type,
         as name: String? = nil,
         interfaces: [Any.Type] = [],
@@ -137,7 +136,7 @@ public extension Type {
         )
     }
 
-    convenience init(
+    public convenience init(
         resolver _: Resolver.Type,
         context _: Context.Type,
         _ type: ObjectType.Type,

--- a/Sources/Graphiti/Union/Union.swift
+++ b/Sources/Graphiti/Union/Union.swift
@@ -4,10 +4,7 @@ public final class Union<
     Resolver: Sendable,
     Context: Sendable,
     UnionType
->: TypeComponent<
-    Resolver,
-    Context
-> {
+>: TypeComponent<Resolver, Context> {
     private let members: [Any.Type]
 
     override func update(typeProvider: SchemaTypeProvider, coders _: Coders) throws {
@@ -38,8 +35,8 @@ public final class Union<
     }
 }
 
-public extension Union {
-    convenience init(
+extension Union {
+    public convenience init(
         _ type: UnionType.Type,
         as name: String? = nil,
         members: Any.Type...
@@ -47,7 +44,7 @@ public extension Union {
         self.init(type: type, name: name, members: members)
     }
 
-    convenience init(
+    public convenience init(
         _ type: UnionType.Type,
         as name: String? = nil,
         members: [Any.Type]

--- a/Sources/Graphiti/Validation/NoIntrospectionRule.swift
+++ b/Sources/Graphiti/Validation/NoIntrospectionRule.swift
@@ -4,10 +4,13 @@ import GraphQL
 public func NoIntrospectionRule(context: ValidationContext) -> Visitor {
     return Visitor(enter: { node, _, _, _, _ in
         if let field = node as? GraphQL.Field, ["__schema", "__type"].contains(field.name.value) {
-            context.report(error: .init(
-                message: "GraphQL introspection is not allowed, but the query contained __schema or __type",
-                nodes: [node]
-            ))
+            context.report(
+                error: .init(
+                    message:
+                        "GraphQL introspection is not allowed, but the query contained __schema or __type",
+                    nodes: [node]
+                )
+            )
         }
         return .continue
     })

--- a/Sources/Graphiti/Value/Value.swift
+++ b/Sources/Graphiti/Value/Value.swift
@@ -10,19 +10,19 @@ public final class Value<EnumType: Encodable & RawRepresentable> where EnumType.
     }
 }
 
-public extension Value {
-    convenience init(_ value: EnumType) {
+extension Value {
+    public convenience init(_ value: EnumType) {
         self.init(value: value)
     }
 
     @discardableResult
-    func description(_ description: String) -> Self {
+    public func description(_ description: String) -> Self {
         self.description = description
         return self
     }
 
     @discardableResult
-    func deprecationReason(_ deprecationReason: String) -> Self {
+    public func deprecationReason(_ deprecationReason: String) -> Self {
         self.deprecationReason = deprecationReason
         return self
     }

--- a/Tests/GraphitiTests/ConnectionTests.swift
+++ b/Tests/GraphitiTests/ConnectionTests.swift
@@ -43,30 +43,30 @@ struct ConnectionTests {
     @Test func connection() async throws {
         let result = try await schema.execute(
             request: """
-            {
-                comments {
-                    edges {
-                        cursor
-                        node {
-                            id
-                            message
+                {
+                    comments {
+                        edges {
+                            cursor
+                            node {
+                                id
+                                message
+                            }
+                        }
+                        pageInfo {
+                            hasPreviousPage
+                            hasNextPage
+                            startCursor
+                            endCursor
                         }
                     }
-                    pageInfo {
-                        hasPreviousPage
-                        hasNextPage
-                        startCursor
-                        endCursor
-                    }
                 }
-            }
-            """,
+                """,
             resolver: .init(),
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(
+            result
+                == .init(
                     data: [
                         "comments": [
                             "edges": [
@@ -98,7 +98,7 @@ struct ConnectionTests {
                                 "startCursor": "MQ==",
                                 "endCursor": "Mw==",
                             ],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -108,29 +108,29 @@ struct ConnectionTests {
     @Test func first() async throws {
         let result = try await schema.execute(
             request: """
-            {
-                comments(first: 1) {
-                    edges {
-                        node {
-                            id
-                            message
+                {
+                    comments(first: 1) {
+                        edges {
+                            node {
+                                id
+                                message
+                            }
+                        }
+                        pageInfo {
+                            hasPreviousPage
+                            hasNextPage
+                            startCursor
+                            endCursor
                         }
                     }
-                    pageInfo {
-                        hasPreviousPage
-                        hasNextPage
-                        startCursor
-                        endCursor
-                    }
                 }
-            }
-            """,
+                """,
             resolver: .init(),
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(
+            result
+                == .init(
                     data: [
                         "comments": [
                             "edges": [
@@ -138,8 +138,8 @@ struct ConnectionTests {
                                     "node": [
                                         "id": 1,
                                         "message": "Hello",
-                                    ],
-                                ],
+                                    ]
+                                ]
                             ],
                             "pageInfo": [
                                 "hasPreviousPage": false,
@@ -147,7 +147,7 @@ struct ConnectionTests {
                                 "startCursor": "MQ==",
                                 "endCursor": "MQ==",
                             ],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -157,29 +157,29 @@ struct ConnectionTests {
     @Test func after() async throws {
         let result = try await schema.execute(
             request: """
-            {
-                comments(after: "MQ==") {
-                    edges {
-                        node {
-                            id
-                            message
+                {
+                    comments(after: "MQ==") {
+                        edges {
+                            node {
+                                id
+                                message
+                            }
+                        }
+                        pageInfo {
+                            hasPreviousPage
+                            hasNextPage
+                            startCursor
+                            endCursor
                         }
                     }
-                    pageInfo {
-                        hasPreviousPage
-                        hasNextPage
-                        startCursor
-                        endCursor
-                    }
                 }
-            }
-            """,
+                """,
             resolver: .init(),
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(
+            result
+                == .init(
                     data: [
                         "comments": [
                             "edges": [
@@ -187,13 +187,13 @@ struct ConnectionTests {
                                     "node": [
                                         "id": 2,
                                         "message": "What's up?",
-                                    ],
+                                    ]
                                 ],
                                 [
                                     "node": [
                                         "id": 3,
                                         "message": "Goodbye",
-                                    ],
+                                    ]
                                 ],
                             ],
                             "pageInfo": [
@@ -202,7 +202,7 @@ struct ConnectionTests {
                                 "startCursor": "Mg==",
                                 "endCursor": "Mw==",
                             ],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -212,29 +212,29 @@ struct ConnectionTests {
     @Test func firstAfter() async throws {
         let result = try await schema.execute(
             request: """
-            {
-                comments(first: 1, after: "MQ==") {
-                    edges {
-                        node {
-                            id
-                            message
+                {
+                    comments(first: 1, after: "MQ==") {
+                        edges {
+                            node {
+                                id
+                                message
+                            }
+                        }
+                        pageInfo {
+                            hasPreviousPage
+                            hasNextPage
+                            startCursor
+                            endCursor
                         }
                     }
-                    pageInfo {
-                        hasPreviousPage
-                        hasNextPage
-                        startCursor
-                        endCursor
-                    }
                 }
-            }
-            """,
+                """,
             resolver: .init(),
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(
+            result
+                == .init(
                     data: [
                         "comments": [
                             "edges": [
@@ -242,8 +242,8 @@ struct ConnectionTests {
                                     "node": [
                                         "id": 2,
                                         "message": "What's up?",
-                                    ],
-                                ],
+                                    ]
+                                ]
                             ],
                             "pageInfo": [
                                 "hasPreviousPage": false,
@@ -251,7 +251,7 @@ struct ConnectionTests {
                                 "startCursor": "Mg==",
                                 "endCursor": "Mg==",
                             ],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -261,29 +261,29 @@ struct ConnectionTests {
     @Test func last() async throws {
         let result = try await schema.execute(
             request: """
-            {
-                comments(last: 1) {
-                    edges {
-                        node {
-                            id
-                            message
+                {
+                    comments(last: 1) {
+                        edges {
+                            node {
+                                id
+                                message
+                            }
+                        }
+                        pageInfo {
+                            hasPreviousPage
+                            hasNextPage
+                            startCursor
+                            endCursor
                         }
                     }
-                    pageInfo {
-                        hasPreviousPage
-                        hasNextPage
-                        startCursor
-                        endCursor
-                    }
                 }
-            }
-            """,
+                """,
             resolver: .init(),
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(
+            result
+                == .init(
                     data: [
                         "comments": [
                             "edges": [
@@ -291,8 +291,8 @@ struct ConnectionTests {
                                     "node": [
                                         "id": 3,
                                         "message": "Goodbye",
-                                    ],
-                                ],
+                                    ]
+                                ]
                             ],
                             "pageInfo": [
                                 "hasPreviousPage": true,
@@ -300,7 +300,7 @@ struct ConnectionTests {
                                 "startCursor": "Mw==",
                                 "endCursor": "Mw==",
                             ],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -310,29 +310,29 @@ struct ConnectionTests {
     @Test func before() async throws {
         let result = try await schema.execute(
             request: """
-            {
-                comments(before: "Mw==") {
-                    edges {
-                        node {
-                            id
-                            message
+                {
+                    comments(before: "Mw==") {
+                        edges {
+                            node {
+                                id
+                                message
+                            }
+                        }
+                        pageInfo {
+                            hasPreviousPage
+                            hasNextPage
+                            startCursor
+                            endCursor
                         }
                     }
-                    pageInfo {
-                        hasPreviousPage
-                        hasNextPage
-                        startCursor
-                        endCursor
-                    }
                 }
-            }
-            """,
+                """,
             resolver: .init(),
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(
+            result
+                == .init(
                     data: [
                         "comments": [
                             "edges": [
@@ -340,13 +340,13 @@ struct ConnectionTests {
                                     "node": [
                                         "id": 1,
                                         "message": "Hello",
-                                    ],
+                                    ]
                                 ],
                                 [
                                     "node": [
                                         "id": 2,
                                         "message": "What's up?",
-                                    ],
+                                    ]
                                 ],
                             ],
                             "pageInfo": [
@@ -355,7 +355,7 @@ struct ConnectionTests {
                                 "startCursor": "MQ==",
                                 "endCursor": "Mg==",
                             ],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -365,29 +365,29 @@ struct ConnectionTests {
     @Test func lastBefore() async throws {
         let result = try await schema.execute(
             request: """
-            {
-                comments(last: 1, before: "Mw==") {
-                    edges {
-                        node {
-                            id
-                            message
+                {
+                    comments(last: 1, before: "Mw==") {
+                        edges {
+                            node {
+                                id
+                                message
+                            }
+                        }
+                        pageInfo {
+                            hasPreviousPage
+                            hasNextPage
+                            startCursor
+                            endCursor
                         }
                     }
-                    pageInfo {
-                        hasPreviousPage
-                        hasNextPage
-                        startCursor
-                        endCursor
-                    }
                 }
-            }
-            """,
+                """,
             resolver: .init(),
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(
+            result
+                == .init(
                     data: [
                         "comments": [
                             "edges": [
@@ -395,8 +395,8 @@ struct ConnectionTests {
                                     "node": [
                                         "id": 2,
                                         "message": "What's up?",
-                                    ],
-                                ],
+                                    ]
+                                ]
                             ],
                             "pageInfo": [
                                 "hasPreviousPage": true,
@@ -404,7 +404,7 @@ struct ConnectionTests {
                                 "startCursor": "Mg==",
                                 "endCursor": "Mg==",
                             ],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -414,29 +414,29 @@ struct ConnectionTests {
     @Test func afterBefore() async throws {
         let result = try await schema.execute(
             request: """
-            {
-                comments(after: "MQ==", before: "Mw==") {
-                    edges {
-                        node {
-                            id
-                            message
+                {
+                    comments(after: "MQ==", before: "Mw==") {
+                        edges {
+                            node {
+                                id
+                                message
+                            }
+                        }
+                        pageInfo {
+                            hasPreviousPage
+                            hasNextPage
+                            startCursor
+                            endCursor
                         }
                     }
-                    pageInfo {
-                        hasPreviousPage
-                        hasNextPage
-                        startCursor
-                        endCursor
-                    }
                 }
-            }
-            """,
+                """,
             resolver: .init(),
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(
+            result
+                == .init(
                     data: [
                         "comments": [
                             "edges": [
@@ -444,8 +444,8 @@ struct ConnectionTests {
                                     "node": [
                                         "id": 2,
                                         "message": "What's up?",
-                                    ],
-                                ],
+                                    ]
+                                ]
                             ],
                             "pageInfo": [
                                 "hasPreviousPage": false,
@@ -453,7 +453,7 @@ struct ConnectionTests {
                                 "startCursor": "Mg==",
                                 "endCursor": "Mg==",
                             ],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -508,25 +508,25 @@ struct ConnectionTests {
 
         let result = try await schema.execute(
             request: """
-            {
-                chatObject {
-                    messages {
-                        edges {
-                            node {
-                                id
-                                text
+                {
+                    chatObject {
+                        messages {
+                            edges {
+                                node {
+                                    id
+                                    text
+                                }
                             }
                         }
                     }
                 }
-            }
-            """,
+                """,
             resolver: .init(),
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(
+            result
+                == .init(
                     data: [
                         "chatObject": [
                             "messages": [
@@ -535,17 +535,17 @@ struct ConnectionTests {
                                         "node": [
                                             "id": 1,
                                             "text": "a",
-                                        ],
+                                        ]
                                     ],
                                     [
                                         "node": [
                                             "id": 2,
                                             "text": "b",
-                                        ],
+                                        ]
                                     ],
-                                ],
-                            ],
-                        ],
+                                ]
+                            ]
+                        ]
                     ]
                 )
         )

--- a/Tests/GraphitiTests/DefaultValueTests.swift
+++ b/Tests/GraphitiTests/DefaultValueTests.swift
@@ -1,95 +1,89 @@
-import Graphiti
 import GraphQL
+import Graphiti
 import Testing
 
 struct DefaultValueTests {
     @Test func boolDefault() async throws {
         let result = try await DefaultValueAPI().execute(
             request: """
-            {
-                bool
-            }
-            """,
+                {
+                    bool
+                }
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(data: ["bool": true])
+            result == .init(data: ["bool": true])
         )
     }
 
     @Test func intDefault() async throws {
         let result = try await DefaultValueAPI().execute(
             request: """
-            {
-                int
-            }
-            """,
+                {
+                    int
+                }
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(data: ["int": 1])
+            result == .init(data: ["int": 1])
         )
     }
 
     @Test func floatDefault() async throws {
         let result = try await DefaultValueAPI().execute(
             request: """
-            {
-                float
-            }
-            """,
+                {
+                    float
+                }
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(data: ["float": 1.1])
+            result == .init(data: ["float": 1.1])
         )
     }
 
     @Test func stringDefault() async throws {
         let result = try await DefaultValueAPI().execute(
             request: """
-            {
-                string
-            }
-            """,
+                {
+                    string
+                }
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(data: ["string": "hello"])
+            result == .init(data: ["string": "hello"])
         )
     }
 
     @Test func enumDefault() async throws {
         let result = try await DefaultValueAPI().execute(
             request: """
-            {
-                enum
-            }
-            """,
+                {
+                    enum
+                }
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(data: ["enum": "valueA"])
+            result == .init(data: ["enum": "valueA"])
         )
     }
 
     @Test func arrayDefault() async throws {
         let result = try await DefaultValueAPI().execute(
             request: """
-            {
-                array
-            }
-            """,
+                {
+                    array
+                }
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(data: ["array": ["a", "b", "c"]])
+            result == .init(data: ["array": ["a", "b", "c"]])
         )
     }
 
@@ -97,22 +91,22 @@ struct DefaultValueTests {
         // Test input object argument default
         var result = try await DefaultValueAPI().execute(
             request: """
-            {
-                input {
-                bool
-                int
-                float
-                string
-                enum
-                array
+                {
+                    input {
+                    bool
+                    int
+                    float
+                    string
+                    enum
+                    array
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(data: [
+            result
+                == .init(data: [
                     "input": [
                         "bool": true,
                         "int": 1,
@@ -120,29 +114,29 @@ struct DefaultValueTests {
                         "string": "hello",
                         "enum": "valueA",
                         "array": ["a", "b", "c"],
-                    ],
+                    ]
                 ])
         )
 
         // Test input object field defaults
         result = try await DefaultValueAPI().execute(
             request: """
-            {
-                input(input: {bool: true}) {
-                bool
-                int
-                float
-                string
-                enum
-                array
+                {
+                    input(input: {bool: true}) {
+                    bool
+                    int
+                    float
+                    string
+                    enum
+                    array
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                .init(data: [
+            result
+                == .init(data: [
                     "input": [
                         "bool": true,
                         "int": 1,
@@ -150,7 +144,7 @@ struct DefaultValueTests {
                         "string": "hello",
                         "enum": "valueA",
                         "array": ["a", "b", "c"],
-                    ],
+                    ]
                 ])
         )
     }
@@ -269,14 +263,16 @@ struct DefaultValueAPI: API {
                 Argument("array", at: \.array).defaultValue(["a", "b", "c"])
             }
             Field("input", at: Resolver.input) {
-                Argument("input", at: \.input).defaultValue(.init(
-                    bool: true,
-                    int: 1,
-                    float: 1.1,
-                    string: "hello",
-                    enum: .valueA,
-                    array: ["a", "b", "c"]
-                ))
+                Argument("input", at: \.input).defaultValue(
+                    .init(
+                        bool: true,
+                        int: 1,
+                        float: 1.1,
+                        string: "hello",
+                        enum: .valueA,
+                        array: ["a", "b", "c"]
+                    )
+                )
             }
         }
     }

--- a/Tests/GraphitiTests/DirectiveTests/DirectiveTests.swift
+++ b/Tests/GraphitiTests/DirectiveTests/DirectiveTests.swift
@@ -1,22 +1,23 @@
-@testable import Graphiti
 import GraphQL
 import Testing
+
+@testable import Graphiti
 
 struct DirectiveTests {
     private let api = StarWarsAPI()
 
     @Test func skip() async throws {
         let query = """
-        query FetchHeroNameWithSkip($skipName: Boolean!) {
-            hero {
-                id
-                name @skip(if: $skipName)
+            query FetchHeroNameWithSkip($skipName: Boolean!) {
+                hero {
+                    id
+                    name @skip(if: $skipName)
+                }
             }
-        }
-        """
+            """
 
         let input: [String: Map] = [
-            "skipName": true,
+            "skipName": true
         ]
 
         let response = try await api.execute(
@@ -28,8 +29,8 @@ struct DirectiveTests {
         let expected = GraphQLResult(
             data: [
                 "hero": [
-                    "id": "2001",
-                ],
+                    "id": "2001"
+                ]
             ]
         )
 
@@ -38,16 +39,16 @@ struct DirectiveTests {
 
     @Test func include() async throws {
         let query = """
-        query FetchHeroNameWithSkip($includeName: Boolean!) {
-            hero {
-                id
-                name @include(if: $includeName)
+            query FetchHeroNameWithSkip($includeName: Boolean!) {
+                hero {
+                    id
+                    name @include(if: $includeName)
+                }
             }
-        }
-        """
+            """
 
         let input: [String: Map] = [
-            "includeName": false,
+            "includeName": false
         ]
 
         let response = try await api.execute(
@@ -59,8 +60,8 @@ struct DirectiveTests {
         let expected = GraphQLResult(
             data: [
                 "hero": [
-                    "id": "2001",
-                ],
+                    "id": "2001"
+                ]
             ]
         )
 
@@ -70,23 +71,23 @@ struct DirectiveTests {
     @Test func oneOfAcceptsGoodValue() async throws {
         let result = try await OneOfAPI().execute(
             request: """
-            query {
-                test(input: {a: "abc"}) {
-                    a
-                    b
+                query {
+                    test(input: {a: "abc"}) {
+                        a
+                        b
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "test": [
                             "a": "abc",
                             "b": .null,
-                        ],
+                        ]
                     ]
                 )
         )
@@ -95,18 +96,18 @@ struct DirectiveTests {
     @Test func oneOfRejectsBadValue() async throws {
         let result = try await OneOfAPI().execute(
             request: """
-            query {
-                test(input: {a: "abc", b: 123}) {
-                    a
-                    b
+                query {
+                    test(input: {a: "abc", b: 123}) {
+                        a
+                        b
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result.errors[0].message ==
-                #"OneOf Input Object "TestInputObject" must specify exactly one key."#
+            result.errors[0].message
+                == #"OneOf Input Object "TestInputObject" must specify exactly one key."#
         )
     }
 

--- a/Tests/GraphitiTests/FederationTests/FederationOnlySchemaTests.swift
+++ b/Tests/GraphitiTests/FederationTests/FederationOnlySchemaTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Graphiti
 import GraphQL
+import Graphiti
 import Testing
 
 struct FederationOnlySchemaTests {
@@ -83,8 +83,8 @@ struct FederationOnlySchemaTests {
     @Test func userFederationSimple() async throws {
         let representations: [String: Map] = [
             "representations": [
-                ["__typename": "User", "id": "1234"],
-            ],
+                ["__typename": "User", "id": "1234"]
+            ]
         ]
 
         let query =
@@ -100,13 +100,13 @@ struct FederationOnlySchemaTests {
 
         let result = try await execute(request: query, variables: representations)
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "_entities": [
                         [
-                            "id": "1234",
-                        ],
-                    ],
+                            "id": "1234"
+                        ]
+                    ]
                 ])
         )
     }
@@ -114,8 +114,8 @@ struct FederationOnlySchemaTests {
     @Test func userFederationNested() async throws {
         let representations: [String: Map] = [
             "representations": [
-                ["__typename": "User", "id": "1234"],
-            ],
+                ["__typename": "User", "id": "1234"]
+            ]
         ]
 
         let query =
@@ -132,8 +132,8 @@ struct FederationOnlySchemaTests {
 
         let result = try await execute(request: query, variables: representations)
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "_entities": [
                         [
                             "id": "1234",
@@ -141,8 +141,8 @@ struct FederationOnlySchemaTests {
                                 "name": "User 1234",
                                 "email": "1234@example.com",
                             ],
-                        ],
-                    ],
+                        ]
+                    ]
                 ])
         )
     }
@@ -150,8 +150,8 @@ struct FederationOnlySchemaTests {
     @Test func userFederationNestedOptional() async throws {
         let representations: [String: Map] = [
             "representations": [
-                ["__typename": "User", "id": "1"],
-            ],
+                ["__typename": "User", "id": "1"]
+            ]
         ]
 
         let query =
@@ -168,8 +168,8 @@ struct FederationOnlySchemaTests {
 
         let result = try await execute(request: query, variables: representations)
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "_entities": [
                         [
                             "id": "1",
@@ -177,8 +177,8 @@ struct FederationOnlySchemaTests {
                                 "name": "User 1",
                                 "email": .null,
                             ],
-                        ],
-                    ],
+                        ]
+                    ]
                 ])
         )
     }

--- a/Tests/GraphitiTests/FederationTests/FederationTests.swift
+++ b/Tests/GraphitiTests/FederationTests/FederationTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Graphiti
 import GraphQL
+import Graphiti
 import Testing
 
 struct FederationTests {
@@ -21,11 +21,11 @@ struct FederationTests {
         let result = try await execute(request: Self.query("service"))
         let sdl = try Self.loadSDL()
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "_service": [
-                        "sdl": Map(stringLiteral: sdl),
-                    ],
+                        "sdl": Map(stringLiteral: sdl)
+                    ]
                 ])
         )
     }
@@ -33,14 +33,14 @@ struct FederationTests {
     @Test func entityKey() async throws {
         let representations: [String: Map] = [
             "representations": [
-                ["__typename": "User", "email": "support@apollographql.com"],
-            ],
+                ["__typename": "User", "email": "support@apollographql.com"]
+            ]
         ]
 
         let result = try await execute(request: Self.query("entities"), variables: representations)
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "_entities": [
                         [
                             "email": "support@apollographql.com",
@@ -48,8 +48,8 @@ struct FederationTests {
                             "totalProductsCreated": 1337,
                             "yearsOfEmployment": 10,
                             "averageProductsCreatedPerYear": 133,
-                        ],
-                    ],
+                        ]
+                    ]
                 ])
         )
     }
@@ -61,14 +61,14 @@ struct FederationTests {
                     "__typename": "DeprecatedProduct",
                     "sku": "apollo-federation-v1",
                     "package": "@apollo/federation-v1",
-                ],
-            ],
+                ]
+            ]
         ]
 
         let result = try await execute(request: Self.query("entities"), variables: representations)
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "_entities": [
                         [
                             "sku": "apollo-federation-v1",
@@ -81,8 +81,8 @@ struct FederationTests {
                                 "yearsOfEmployment": 10,
                                 "averageProductsCreatedPerYear": 133,
                             ],
-                        ],
-                    ],
+                        ]
+                    ]
                 ])
         )
     }
@@ -90,14 +90,14 @@ struct FederationTests {
     @Test func entityCompositeKey() async throws {
         let representations: [String: Map] = [
             "representations": [
-                ["__typename": "ProductResearch", "study": ["caseNumber": "1234"]],
-            ],
+                ["__typename": "ProductResearch", "study": ["caseNumber": "1234"]]
+            ]
         ]
 
         let result = try await execute(request: Self.query("entities"), variables: representations)
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "_entities": [
                         [
                             "study": [
@@ -105,8 +105,8 @@ struct FederationTests {
                                 "description": "Federation Study",
                             ],
                             "outcome": nil,
-                        ],
-                    ],
+                        ]
+                    ]
                 ])
         )
     }
@@ -117,20 +117,20 @@ struct FederationTests {
                 ["__typename": "Product", "id": "apollo-federation"],
                 ["__typename": "Product", "sku": "federation", "package": "@apollo/federation"],
                 ["__typename": "Product", "sku": "studio", "variation": ["id": "platform"]],
-            ],
+            ]
         ]
 
         let result = try await execute(request: Self.query("entities"), variables: representations)
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "_entities": [
                         [
                             "id": "apollo-federation",
                             "sku": "federation",
                             "package": "@apollo/federation",
                             "variation": [
-                                "id": "OSS",
+                                "id": "OSS"
                             ],
                             "dimensions": [
                                 "size": "small",
@@ -152,7 +152,7 @@ struct FederationTests {
                                         "caseNumber": "1234",
                                         "description": "Federation Study",
                                     ],
-                                ],
+                                ]
                             ],
                         ],
                         [
@@ -160,7 +160,7 @@ struct FederationTests {
                             "sku": "federation",
                             "package": "@apollo/federation",
                             "variation": [
-                                "id": "OSS",
+                                "id": "OSS"
                             ],
                             "dimensions": [
                                 "size": "small",
@@ -182,7 +182,7 @@ struct FederationTests {
                                         "caseNumber": "1234",
                                         "description": "Federation Study",
                                     ],
-                                ],
+                                ]
                             ],
                         ],
                         [
@@ -190,7 +190,7 @@ struct FederationTests {
                             "sku": "studio",
                             "package": "",
                             "variation": [
-                                "id": "platform",
+                                "id": "platform"
                             ],
                             "dimensions": [
                                 "size": "small",
@@ -212,10 +212,10 @@ struct FederationTests {
                                         "caseNumber": "1235",
                                         "description": "Studio Study",
                                     ],
-                                ],
+                                ]
                             ],
                         ],
-                    ],
+                    ]
                 ])
         )
     }

--- a/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
+++ b/Tests/GraphitiTests/HelloWorldTests/HelloWorldTests.swift
@@ -1,6 +1,7 @@
-@testable import Graphiti
 import GraphQL
 import Testing
+
+@testable import Graphiti
 
 struct ID: Codable {
     let id: String
@@ -176,13 +177,13 @@ struct HelloWorldTests {
             context: api.context
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     errors: [
                         GraphQLError(
                             message: "Cannot query field \"boyhowdy\" on type \"Query\".",
                             locations: [SourceLocation(line: 1, column: 3)]
-                        ),
+                        )
                     ]
                 )
         )
@@ -191,10 +192,10 @@ struct HelloWorldTests {
     @Test func scalar() async throws {
         var result = try await api.execute(
             request: """
-            query Query($float: Float!) {
-                float(float: $float)
-            }
-            """,
+                query Query($float: Float!) {
+                    float(float: $float)
+                }
+                """,
             context: api.context,
             variables: ["float": 4]
         )
@@ -202,20 +203,20 @@ struct HelloWorldTests {
 
         result = try await api.execute(
             request: """
-            query Query {
-                float(float: 4)
-            }
-            """,
+                query Query {
+                    float(float: 4)
+                }
+                """,
             context: api.context
         )
         #expect(result == GraphQLResult(data: ["float": 4.0]))
 
         result = try await api.execute(
             request: """
-            query Query($id: ID!) {
-                id(id: $id)
-            }
-            """,
+                query Query($id: ID!) {
+                    id(id: $id)
+                }
+                """,
             context: api.context,
             variables: ["id": "85b8d502-8190-40ab-b18f-88edd297d8b6"]
         )
@@ -223,10 +224,10 @@ struct HelloWorldTests {
 
         result = try await api.execute(
             request: """
-            query Query {
-                id(id: "85b8d502-8190-40ab-b18f-88edd297d8b6")
-            }
-            """,
+                query Query {
+                    id(id: "85b8d502-8190-40ab-b18f-88edd297d8b6")
+                }
+                """,
             context: api.context
         )
         #expect(result == GraphQLResult(data: ["id": "85b8d502-8190-40ab-b18f-88edd297d8b6"]))
@@ -235,19 +236,19 @@ struct HelloWorldTests {
     @Test func input() async throws {
         let result = try await api.execute(
             request: """
-            mutation addUser($user: UserInput!) {
-                addUser(user: $user) {
-                    id,
-                    name
+                mutation addUser($user: UserInput!) {
+                    addUser(user: $user) {
+                        id,
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: api.context,
             variables: ["user": ["id": "123", "name": "bob"]]
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: ["addUser": ["id": "123", "name": "bob"]]
                 )
         )
@@ -257,20 +258,20 @@ struct HelloWorldTests {
         let result = try await api.execute(
             request: GraphQLRequest(
                 query: """
-                mutation addUser($user: UserInput!) {
-                    addUser(user: $user) {
-                        id,
-                        name
+                    mutation addUser($user: UserInput!) {
+                        addUser(user: $user) {
+                            id,
+                            name
+                        }
                     }
-                }
-                """,
+                    """,
                 variables: ["user": ["id": "123", "name": "bob"]]
             ),
             context: api.context
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: ["addUser": ["id": "123", "name": "bob"]]
                 )
         )
@@ -279,35 +280,35 @@ struct HelloWorldTests {
     @Test func inputRecursive() async throws {
         let result = try await api.execute(
             request: """
-            mutation addUser($user: UserInput!) {
-                addUser(user: $user) {
-                    id,
-                    name,
-                    friends {
+                mutation addUser($user: UserInput!) {
+                    addUser(user: $user) {
                         id,
-                        name
+                        name,
+                        friends {
+                            id,
+                            name
+                        }
                     }
                 }
-            }
-            """,
+                """,
             context: api.context,
             variables: [
                 "user": [
                     "id": "123",
                     "name": "bob",
                     "friends": [["id": "124", "name": "jeff"]],
-                ],
+                ]
             ]
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "addUser": [
                             "id": "123",
                             "name": "bob",
                             "friends": [["id": "124", "name": "jeff"]],
-                        ],
+                        ]
                     ]
                 )
         )

--- a/Tests/GraphitiTests/PartialSchemaTests.swift
+++ b/Tests/GraphitiTests/PartialSchemaTests.swift
@@ -1,5 +1,5 @@
-import Graphiti
 import GraphQL
+import Graphiti
 import Testing
 
 struct PartialSchemaTests {
@@ -111,20 +111,20 @@ struct PartialSchemaTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                human(id: "1000") {
-                    name
+                query {
+                    human(id: "1000") {
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "human": [
-                        "name": "Luke Skywalker",
-                    ],
+                        "name": "Luke Skywalker"
+                    ]
                 ])
         )
     }
@@ -142,20 +142,20 @@ struct PartialSchemaTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                human(id: "1000") {
-                    name
+                query {
+                    human(id: "1000") {
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "human": [
-                        "name": "Luke Skywalker",
-                    ],
+                        "name": "Luke Skywalker"
+                    ]
                 ])
         )
     }
@@ -173,20 +173,20 @@ struct PartialSchemaTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                human(id: "1000") {
-                    name
+                query {
+                    human(id: "1000") {
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "human": [
-                        "name": "Luke Skywalker",
-                    ],
+                        "name": "Luke Skywalker"
+                    ]
                 ])
         )
     }
@@ -294,20 +294,20 @@ struct PartialSchemaTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                human(id: "1000") {
-                    name
+                query {
+                    human(id: "1000") {
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "human": [
-                        "name": "Luke Skywalker",
-                    ],
+                        "name": "Luke Skywalker"
+                    ]
                 ])
         )
     }

--- a/Tests/GraphitiTests/ProductAPI/ProductContext.swift
+++ b/Tests/GraphitiTests/ProductAPI/ProductContext.swift
@@ -7,7 +7,7 @@ struct ProductContext {
             size: "small",
             weight: 1,
             unit: "kg"
-        ),
+        )
     ]
 
     static let users = [
@@ -16,7 +16,7 @@ struct ProductContext {
             name: "Jane Smith",
             totalProductsCreated: 1337,
             yearsOfEmployment: 10
-        ),
+        )
     ]
 
     static let deprecatedProducts = [
@@ -25,7 +25,7 @@ struct ProductContext {
             package: "@apollo/federation-v1",
             reason: "Migrate to Federation V2",
             createdBy: users[0]
-        ),
+        )
     ]
 
     static let productsResearch = [

--- a/Tests/GraphitiTests/ProductAPI/ProductResolver.swift
+++ b/Tests/GraphitiTests/ProductAPI/ProductResolver.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Graphiti
 import GraphQL
+import Graphiti
 
 struct ProductResolver {
     var sdl: String

--- a/Tests/GraphitiTests/ScalarTests.swift
+++ b/Tests/GraphitiTests/ScalarTests.swift
@@ -1,7 +1,8 @@
 import Foundation
-@testable import Graphiti
 import GraphQL
 import Testing
+
+@testable import Graphiti
 
 struct ScalarTests {
     // MARK: Test UUID converts to String as expected
@@ -33,20 +34,20 @@ struct ScalarTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                uuid {
-                value
+                query {
+                    uuid {
+                    value
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "uuid": [
-                        "value": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
-                    ],
+                        "value": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
+                    ]
                 ])
         )
     }
@@ -84,20 +85,20 @@ struct ScalarTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                uuid (value: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F") {
-                value
+                query {
+                    uuid (value: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F") {
+                    value
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "uuid": [
-                        "value": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
-                    ],
+                        "value": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
+                    ]
                 ])
         )
     }
@@ -142,20 +143,20 @@ struct ScalarTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                uuid (input: {value: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"}) {
-                value
+                query {
+                    uuid (input: {value: "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"}) {
+                    value
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "uuid": [
-                        "value": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F",
-                    ],
+                        "value": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
+                    ]
                 ])
         )
     }
@@ -194,20 +195,20 @@ struct ScalarTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                date {
-                value
+                query {
+                    date {
+                    value
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "date": [
-                        "value": "2001-01-01T00:00:00Z",
-                    ],
+                        "value": "2001-01-01T00:00:00Z"
+                    ]
                 ])
         )
     }
@@ -250,20 +251,20 @@ struct ScalarTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                date (value: "2001-01-01T00:00:00Z") {
-                value
+                query {
+                    date (value: "2001-01-01T00:00:00Z") {
+                    value
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "date": [
-                        "value": "2001-01-01T00:00:00Z",
-                    ],
+                        "value": "2001-01-01T00:00:00Z"
+                    ]
                 ])
         )
     }
@@ -313,20 +314,20 @@ struct ScalarTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                date (input: {value: "2001-01-01T00:00:00Z"}) {
-                value
+                query {
+                    date (input: {value: "2001-01-01T00:00:00Z"}) {
+                    value
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "date": [
-                        "value": "2001-01-01T00:00:00Z",
-                    ],
+                        "value": "2001-01-01T00:00:00Z"
+                    ]
                 ])
         )
     }
@@ -360,20 +361,20 @@ struct ScalarTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                coord {
-                value
+                query {
+                    coord {
+                    value
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "coord": [
-                        "value": "(0.0, 0.0)",
-                    ],
+                        "value": "(0.0, 0.0)"
+                    ]
                 ])
         )
     }
@@ -411,20 +412,20 @@ struct ScalarTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                coord (value: "(0.0, 0.0)") {
-                value
+                query {
+                    coord (value: "(0.0, 0.0)") {
+                    value
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "coord": [
-                        "value": "(0.0, 0.0)",
-                    ],
+                        "value": "(0.0, 0.0)"
+                    ]
                 ])
         )
     }
@@ -469,20 +470,20 @@ struct ScalarTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                coord (input: {value: "(0.0, 0.0)"}) {
-                value
+                query {
+                    coord (input: {value: "(0.0, 0.0)"}) {
+                    value
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "coord": [
-                        "value": "(0.0, 0.0)",
-                    ],
+                        "value": "(0.0, 0.0)"
+                    ]
                 ])
         )
     }
@@ -517,24 +518,22 @@ struct ScalarTests {
         // Test individual fields because we can't be confident we'll match the ordering of Map's OrderedDictionary
         let result = try await api.execute(
             request: """
-            query {
-              coord {
-                value
-              }
-            }
-            """,
+                query {
+                  coord {
+                    value
+                  }
+                }
+                """,
             context: NoContext()
         )
 
         let value = result.data?.dictionary?["coord"]?.dictionary?["value"]?.dictionary
 
         #expect(
-            value?["longitude"] ==
-                .number(0.0)
+            value?["longitude"] == .number(0.0)
         )
         #expect(
-            value?["latitude"] ==
-                .number(0.0)
+            value?["latitude"] == .number(0.0)
         )
     }
 
@@ -572,24 +571,22 @@ struct ScalarTests {
         // Test individual fields because we can't be confident we'll match the ordering of Map's OrderedDictionary
         let result = try await api.execute(
             request: """
-            query {
-              coord (value: {latitude: 0.0, longitude: 0.0}) {
-                value
-              }
-            }
-            """,
+                query {
+                  coord (value: {latitude: 0.0, longitude: 0.0}) {
+                    value
+                  }
+                }
+                """,
             context: NoContext()
         )
 
         let value = result.data?.dictionary?["coord"]?.dictionary?["value"]?.dictionary
 
         #expect(
-            value?["longitude"] ==
-                .number(0.0)
+            value?["longitude"] == .number(0.0)
         )
         #expect(
-            value?["latitude"] ==
-                .number(0.0)
+            value?["latitude"] == .number(0.0)
         )
     }
 
@@ -634,24 +631,22 @@ struct ScalarTests {
         // Test individual fields because we can't be confident we'll match the ordering of Map's OrderedDictionary
         let result = try await api.execute(
             request: """
-            query {
-              coord (input: {value: {latitude: 0.0, longitude: 0.0}}) {
-                value
-              }
-            }
-            """,
+                query {
+                  coord (input: {value: {latitude: 0.0, longitude: 0.0}}) {
+                    value
+                  }
+                }
+                """,
             context: NoContext()
         )
 
         let value = result.data?.dictionary?["coord"]?.dictionary?["value"]?.dictionary
 
         #expect(
-            value?["longitude"] ==
-                .number(0.0)
+            value?["longitude"] == .number(0.0)
         )
         #expect(
-            value?["latitude"] ==
-                .number(0.0)
+            value?["latitude"] == .number(0.0)
         )
     }
 }

--- a/Tests/GraphitiTests/SchemaBuilderTests.swift
+++ b/Tests/GraphitiTests/SchemaBuilderTests.swift
@@ -1,5 +1,5 @@
-import Graphiti
 import GraphQL
+import Graphiti
 import Testing
 
 struct SchemaBuilderTests {
@@ -103,20 +103,20 @@ struct SchemaBuilderTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                human(id: "1000") {
-                    name
+                query {
+                    human(id: "1000") {
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "human": [
-                        "name": "Luke Skywalker",
-                    ],
+                        "name": "Luke Skywalker"
+                    ]
                 ])
         )
 

--- a/Tests/GraphitiTests/SchemaTests.swift
+++ b/Tests/GraphitiTests/SchemaTests.swift
@@ -1,7 +1,8 @@
 import Foundation
-@testable import Graphiti
 import GraphQL
 import Testing
+
+@testable import Graphiti
 
 struct SchemaTests {
     /// Tests that circularly dependent objects can be used in schema and resolved correctly
@@ -46,24 +47,24 @@ struct SchemaTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                a {
-                b {
-                    name
+                query {
+                    a {
+                    b {
+                        name
+                    }
+                    }
                 }
-                }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "a": [
                         "b": [
-                            "name": "Circular",
-                        ],
-                    ],
+                            "name": "Circular"
+                        ]
+                    ]
                 ])
         )
     }
@@ -112,24 +113,24 @@ struct SchemaTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                user {
-                location {
-                    name
+                query {
+                    user {
+                    location {
+                        name
+                    }
+                    }
                 }
-                }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: [
+            result
+                == GraphQLResult(data: [
                     "user": [
                         "location": [
-                            "name": "Earth",
-                        ],
-                    ],
+                            "name": "Earth"
+                        ]
+                    ]
                 ])
         )
     }
@@ -149,8 +150,8 @@ struct SchemaTests {
             }
         } catch {
             #expect(
-                error as? SchemaError ==
-                    SchemaError(
+                error as? SchemaError
+                    == SchemaError(
                         description: "Schema must contain at least 1 query or federated resolver"
                     )
             )

--- a/Tests/GraphitiTests/StarWarsAPI/StarWarsContext.swift
+++ b/Tests/GraphitiTests/StarWarsAPI/StarWarsContext.swift
@@ -1,10 +1,8 @@
-/**
- * This defines a basic set of data for our Star Wars Schema.
- *
- * This data is hard coded for the sake of the demo, but you could imagine
- * fetching this data from a backend service rather than from hardcoded
- * values in a more complex demo.
- */
+/// This defines a basic set of data for our Star Wars Schema.
+///
+/// This data is hard coded for the sake of the demo, but you could imagine
+/// fetching this data from a backend service rather than from hardcoded
+/// values in a more complex demo.
 public final class StarWarsContext: Sendable {
     private static let tatooine = Planet(
         id: "10001",

--- a/Tests/GraphitiTests/StarWarsAPI/StarWarsResolver.swift
+++ b/Tests/GraphitiTests/StarWarsAPI/StarWarsResolver.swift
@@ -1,31 +1,35 @@
 import Graphiti
 
-public extension Character {
-    var secretBackstory: String? {
+extension Character {
+    public var secretBackstory: String? {
         nil
     }
 
-    func getFriends(context _: StarWarsContext, arguments _: NoArguments) -> [Character] {
+    public func getFriends(context _: StarWarsContext, arguments _: NoArguments) -> [Character] {
         []
     }
 }
 
-public extension Human {
-    func getFriends(context: StarWarsContext, arguments _: NoArguments) -> [Character] {
+extension Human {
+    public func getFriends(context: StarWarsContext, arguments _: NoArguments) -> [Character] {
         context.getFriends(of: self)
     }
 
-    func getSecretBackstory(context: StarWarsContext, arguments _: NoArguments) throws -> String? {
+    public func getSecretBackstory(context: StarWarsContext, arguments _: NoArguments) throws
+        -> String?
+    {
         try context.getSecretBackStory()
     }
 }
 
-public extension Droid {
-    func getFriends(context: StarWarsContext, arguments _: NoArguments) -> [Character] {
+extension Droid {
+    public func getFriends(context: StarWarsContext, arguments _: NoArguments) -> [Character] {
         context.getFriends(of: self)
     }
 
-    func getSecretBackstory(context: StarWarsContext, arguments _: NoArguments) throws -> String? {
+    public func getSecretBackstory(context: StarWarsContext, arguments _: NoArguments) throws
+        -> String?
+    {
         try context.getSecretBackStory()
     }
 }

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsIntrospectionTests.swift
@@ -1,6 +1,7 @@
-@testable import Graphiti
 import GraphQL
 import Testing
+
+@testable import Graphiti
 
 struct StarWarsIntrospectionTests {
     private let api = StarWarsAPI()
@@ -8,78 +9,78 @@ struct StarWarsIntrospectionTests {
     @Test func introspectionTypeQuery() async throws {
         let result = try await api.execute(
             request: """
-            query IntrospectionTypeQuery {
-                __schema {
-                    types {
-                        name
+                query IntrospectionTypeQuery {
+                    __schema {
+                        types {
+                            name
+                        }
                     }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "__schema": [
                             "types": [
                                 [
-                                    "name": "Boolean",
+                                    "name": "Boolean"
                                 ],
                                 [
-                                    "name": "Character",
+                                    "name": "Character"
                                 ],
                                 [
-                                    "name": "Droid",
+                                    "name": "Droid"
                                 ],
                                 [
-                                    "name": "Episode",
+                                    "name": "Episode"
                                 ],
                                 [
-                                    "name": "Human",
+                                    "name": "Human"
                                 ],
                                 [
-                                    "name": "Int",
+                                    "name": "Int"
                                 ],
                                 [
-                                    "name": "Planet",
+                                    "name": "Planet"
                                 ],
                                 [
-                                    "name": "Query",
+                                    "name": "Query"
                                 ],
                                 [
-                                    "name": "SearchResult",
+                                    "name": "SearchResult"
                                 ],
                                 [
-                                    "name": "String",
+                                    "name": "String"
                                 ],
                                 [
-                                    "name": "__Directive",
+                                    "name": "__Directive"
                                 ],
                                 [
-                                    "name": "__DirectiveLocation",
+                                    "name": "__DirectiveLocation"
                                 ],
                                 [
-                                    "name": "__EnumValue",
+                                    "name": "__EnumValue"
                                 ],
                                 [
-                                    "name": "__Field",
+                                    "name": "__Field"
                                 ],
                                 [
-                                    "name": "__InputValue",
+                                    "name": "__InputValue"
                                 ],
                                 [
-                                    "name": "__Schema",
+                                    "name": "__Schema"
                                 ],
                                 [
-                                    "name": "__Type",
+                                    "name": "__Type"
                                 ],
                                 [
-                                    "name": "__TypeKind",
+                                    "name": "__TypeKind"
                                 ],
-                            ],
-                        ],
+                            ]
+                        ]
                     ]
                 )
         )
@@ -88,25 +89,25 @@ struct StarWarsIntrospectionTests {
     @Test func introspectionQueryTypeQuery() async throws {
         let result = try await api.execute(
             request: """
-            query IntrospectionQueryTypeQuery {
-                __schema {
-                    queryType {
-                        name
+                query IntrospectionQueryTypeQuery {
+                    __schema {
+                        queryType {
+                            name
+                        }
                     }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "__schema": [
                             "queryType": [
-                                "name": "Query",
-                            ],
-                        ],
+                                "name": "Query"
+                            ]
+                        ]
                     ]
                 )
         )
@@ -115,21 +116,21 @@ struct StarWarsIntrospectionTests {
     @Test func introspectionDroidTypeQuery() async throws {
         let result = try await api.execute(
             request: """
-            query IntrospectionDroidTypeQuery {
-                __type(name: \"Droid\") {
-                    name
+                query IntrospectionDroidTypeQuery {
+                    __type(name: \"Droid\") {
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "__type": [
-                            "name": "Droid",
-                        ],
+                            "name": "Droid"
+                        ]
                     ]
                 )
         )
@@ -138,23 +139,23 @@ struct StarWarsIntrospectionTests {
     @Test func introspectionDroidKindQuery() async throws {
         let result = try await api.execute(
             request: """
-            query IntrospectionDroidKindQuery {
-                __type(name: \"Droid\") {
-                    name
-                    kind
+                query IntrospectionDroidKindQuery {
+                    __type(name: \"Droid\") {
+                        name
+                        kind
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "__type": [
                             "name": "Droid",
                             "kind": "OBJECT",
-                        ],
+                        ]
                     ]
                 )
         )
@@ -163,23 +164,23 @@ struct StarWarsIntrospectionTests {
     @Test func introspectionCharacterKindQuery() async throws {
         let result = try await api.execute(
             request: """
-            query IntrospectionCharacterKindQuery {
-                __type(name: \"Character\") {
-                    name
-                    kind
+                query IntrospectionCharacterKindQuery {
+                    __type(name: \"Character\") {
+                        name
+                        kind
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "__type": [
                             "name": "Character",
                             "kind": "INTERFACE",
-                        ],
+                        ]
                     ]
                 )
         )
@@ -188,24 +189,24 @@ struct StarWarsIntrospectionTests {
     @Test func introspectionDroidFieldsQuery() async throws {
         let result = try await api.execute(
             request: """
-            query IntrospectionDroidFieldsQuery {
-                __type(name: \"Droid\") {
-                    name
-                    fields {
+                query IntrospectionDroidFieldsQuery {
+                    __type(name: \"Droid\") {
                         name
-                        type {
+                        fields {
                             name
-                            kind
+                            type {
+                                name
+                                kind
+                            }
                         }
                     }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "__type": [
                             "name": "Droid",
@@ -253,7 +254,7 @@ struct StarWarsIntrospectionTests {
                                     ],
                                 ],
                             ],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -262,28 +263,28 @@ struct StarWarsIntrospectionTests {
     @Test func introspectionDroidNestedFieldsQuery() async throws {
         let result = try await api.execute(
             request: """
-            query IntrospectionDroidNestedFieldsQuery {
-                __type(name: \"Droid\") {
-                    name
-                    fields {
+                query IntrospectionDroidNestedFieldsQuery {
+                    __type(name: \"Droid\") {
                         name
-                        type {
+                        fields {
                             name
-                            kind
-                            ofType {
+                            type {
                                 name
                                 kind
+                                ofType {
+                                    name
+                                    kind
+                                }
                             }
                         }
                     }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "__type": [
                             "name": "Droid",
@@ -352,7 +353,7 @@ struct StarWarsIntrospectionTests {
                                     ],
                                 ],
                             ],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -361,34 +362,34 @@ struct StarWarsIntrospectionTests {
     @Test func introspectionFieldArgsQuery() async throws {
         let result = try await api.execute(
             request: """
-            query IntrospectionFieldArgsQuery {
-                __schema {
-                    queryType {
-                        fields {
-                            name
-                            args {
+                query IntrospectionFieldArgsQuery {
+                    __schema {
+                        queryType {
+                            fields {
                                 name
-                                description
-                                type {
+                                args {
                                     name
-                                    kind
-                                    ofType {
+                                    description
+                                    type {
                                         name
                                         kind
+                                        ofType {
+                                            name
+                                            kind
+                                        }
                                     }
-                                }
-                                defaultValue
-                                }
+                                    defaultValue
+                                    }
+                            }
                         }
                     }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "__schema": [
                             "queryType": [
@@ -408,7 +409,7 @@ struct StarWarsIntrospectionTests {
                                                     ],
                                                 ],
                                                 "defaultValue": nil,
-                                            ],
+                                            ]
                                         ],
                                     ],
                                     [
@@ -416,14 +417,15 @@ struct StarWarsIntrospectionTests {
                                         "args": [
                                             [
                                                 "name": "episode",
-                                                "description": "If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.",
+                                                "description":
+                                                    "If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.",
                                                 "type": [
                                                     "name": "Episode",
                                                     "kind": "ENUM",
                                                     "ofType": nil,
                                                 ],
                                                 "defaultValue": nil,
-                                            ],
+                                            ]
                                         ],
                                     ],
                                     [
@@ -441,7 +443,7 @@ struct StarWarsIntrospectionTests {
                                                     ],
                                                 ],
                                                 "defaultValue": nil,
-                                            ],
+                                            ]
                                         ],
                                     ],
                                     [
@@ -459,12 +461,12 @@ struct StarWarsIntrospectionTests {
                                                     ],
                                                 ],
                                                 "defaultValue": "\"R2-D2\"",
-                                            ],
+                                            ]
                                         ],
                                     ],
-                                ],
-                            ],
-                        ],
+                                ]
+                            ]
+                        ]
                     ]
                 )
         )
@@ -473,23 +475,23 @@ struct StarWarsIntrospectionTests {
     @Test func introspectionDroidDescriptionQuery() async throws {
         let result = try await api.execute(
             request: """
-            query IntrospectionDroidDescriptionQuery {
-                __type(name: \"Droid\") {
-                    name
-                    description
+                query IntrospectionDroidDescriptionQuery {
+                    __type(name: \"Droid\") {
+                        name
+                        description
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "__type": [
                             "name": "Droid",
                             "description": "A mechanical creature in the Star Wars universe.",
-                        ],
+                        ]
                     ]
                 )
         )

--- a/Tests/GraphitiTests/StarWarsTests/StarWarsQueryTests.swift
+++ b/Tests/GraphitiTests/StarWarsTests/StarWarsQueryTests.swift
@@ -1,6 +1,7 @@
-@testable import Graphiti
 import GraphQL
 import Testing
+
+@testable import Graphiti
 
 struct StarWarsQueryTests {
     private let api = StarWarsAPI()
@@ -8,38 +9,37 @@ struct StarWarsQueryTests {
     @Test func heroNameQuery() async throws {
         let result = try await api.execute(
             request: """
-            query HeroNameQuery {
-                hero {
-                    name
+                query HeroNameQuery {
+                    hero {
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(data: ["hero": ["name": "R2-D2"]])
+            result == GraphQLResult(data: ["hero": ["name": "R2-D2"]])
         )
     }
 
     @Test func heroNameAndFriendsQuery() async throws {
         let result = try await api.execute(
             request: """
-            query HeroNameAndFriendsQuery {
-                hero {
-                    id
-                    name
-                    friends {
+                query HeroNameAndFriendsQuery {
+                    hero {
+                        id
                         name
+                        friends {
+                            name
+                        }
                     }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "hero": [
                             "id": "2001",
@@ -49,7 +49,7 @@ struct StarWarsQueryTests {
                                 ["name": "Han Solo"],
                                 ["name": "Leia Organa"],
                             ],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -58,24 +58,24 @@ struct StarWarsQueryTests {
     @Test func nestedQuery() async throws {
         let result = try await api.execute(
             request: """
-            query NestedQuery {
-                hero {
-                    name
-                    friends {
+                query NestedQuery {
+                    hero {
                         name
-                        appearsIn
                         friends {
                             name
+                            appearsIn
+                            friends {
+                                name
+                            }
                         }
                     }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "hero": [
                             "name": "R2-D2",
@@ -110,7 +110,7 @@ struct StarWarsQueryTests {
                                     ],
                                 ],
                             ],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -119,21 +119,21 @@ struct StarWarsQueryTests {
     @Test func fetchLukeQuery() async throws {
         let result = try await api.execute(
             request: """
-            query FetchLukeQuery {
-                human(id: "1000") {
-                    name
+                query FetchLukeQuery {
+                    human(id: "1000") {
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "human": [
-                            "name": "Luke Skywalker",
-                        ],
+                            "name": "Luke Skywalker"
+                        ]
                     ]
                 )
         )
@@ -142,64 +142,64 @@ struct StarWarsQueryTests {
     @Test func fetchSomeIDQuery() async throws {
         var result = try await api.execute(
             request: """
-            query FetchSomeIDQuery($someId: String!) {
-                human(id: $someId) {
-                    name
+                query FetchSomeIDQuery($someId: String!) {
+                    human(id: $someId) {
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext(),
             variables: ["someId": "1000"]
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "human": [
-                            "name": "Luke Skywalker",
-                        ],
+                            "name": "Luke Skywalker"
+                        ]
                     ]
                 )
         )
 
         result = try await api.execute(
             request: """
-            query FetchSomeIDQuery($someId: String!) {
-                human(id: $someId) {
-                    name
+                query FetchSomeIDQuery($someId: String!) {
+                    human(id: $someId) {
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext(),
             variables: ["someId": "1002"]
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "human": [
-                            "name": "Han Solo",
-                        ],
+                            "name": "Han Solo"
+                        ]
                     ]
                 )
         )
 
         result = try await api.execute(
             request: """
-            query FetchSomeIDQuery($someId: String!) {
-                human(id: $someId) {
-                    name
+                query FetchSomeIDQuery($someId: String!) {
+                    human(id: $someId) {
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext(),
             variables: ["someId": "not a valid id"]
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
-                        "human": nil,
+                        "human": nil
                     ]
                 )
         )
@@ -208,21 +208,21 @@ struct StarWarsQueryTests {
     @Test func fetchLukeAliasedQuery() async throws {
         let result = try await api.execute(
             request: """
-            query FetchLukeAliasedQuery {
-                luke: human(id: "1000") {
-                    name
+                query FetchLukeAliasedQuery {
+                    luke: human(id: "1000") {
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "luke": [
-                            "name": "Luke Skywalker",
-                        ],
+                            "name": "Luke Skywalker"
+                        ]
                     ]
                 )
         )
@@ -231,26 +231,26 @@ struct StarWarsQueryTests {
     @Test func fetchLukeAndLeiaAliasedQuery() async throws {
         let result = try await api.execute(
             request: """
-            query FetchLukeAndLeiaAliasedQuery {
-                luke: human(id: "1000") {
-                    name
+                query FetchLukeAndLeiaAliasedQuery {
+                    luke: human(id: "1000") {
+                        name
+                    }
+                    leia: human(id: "1003") {
+                        name
+                    }
                 }
-                leia: human(id: "1003") {
-                    name
-                }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "luke": [
-                            "name": "Luke Skywalker",
+                            "name": "Luke Skywalker"
                         ],
                         "leia": [
-                            "name": "Leia Organa",
+                            "name": "Leia Organa"
                         ],
                     ]
                 )
@@ -260,22 +260,22 @@ struct StarWarsQueryTests {
     @Test func duplicateFieldsQuery() async throws {
         let result = try await api.execute(
             request: """
-            query DuplicateFieldsQuery {
-                luke: human(id: "1000") {
-                    name
-                    homePlanet { name }
+                query DuplicateFieldsQuery {
+                    luke: human(id: "1000") {
+                        name
+                        homePlanet { name }
+                    }
+                    leia: human(id: "1003") {
+                        name
+                        homePlanet  { name }
+                    }
                 }
-                leia: human(id: "1003") {
-                    name
-                    homePlanet  { name }
-                }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "luke": [
                             "name": "Luke Skywalker",
@@ -293,24 +293,24 @@ struct StarWarsQueryTests {
     @Test func useFragmentQuery() async throws {
         let result = try await api.execute(
             request: """
-            query UseFragmentQuery {
-                luke: human(id: "1000") {
-                    ...HumanFragment
+                query UseFragmentQuery {
+                    luke: human(id: "1000") {
+                        ...HumanFragment
+                    }
+                    leia: human(id: "1003") {
+                        ...HumanFragment
+                    }
                 }
-                leia: human(id: "1003") {
-                    ...HumanFragment
+                fragment HumanFragment on Human {
+                    name
+                    homePlanet { name }
                 }
-            }
-            fragment HumanFragment on Human {
-                name
-                homePlanet { name }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "luke": [
                             "name": "Luke Skywalker",
@@ -328,23 +328,23 @@ struct StarWarsQueryTests {
     @Test func checkTypeOfR2Query() async throws {
         let result = try await api.execute(
             request: """
-            query CheckTypeOfR2Query {
-                hero {
-                    __typename
-                    name
+                query CheckTypeOfR2Query {
+                    hero {
+                        __typename
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "hero": [
                             "__typename": "Droid",
                             "name": "R2-D2",
-                        ],
+                        ]
                     ]
                 )
         )
@@ -353,23 +353,23 @@ struct StarWarsQueryTests {
     @Test func checkTypeOfLukeQuery() async throws {
         let result = try await api.execute(
             request: """
-            query CheckTypeOfLukeQuery {
-                hero(episode: EMPIRE) {
-                    __typename
-                    name
+                query CheckTypeOfLukeQuery {
+                    hero(episode: EMPIRE) {
+                        __typename
+                        name
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "hero": [
                             "__typename": "Human",
                             "name": "Luke Skywalker",
-                        ],
+                        ]
                     ]
                 )
         )
@@ -378,30 +378,30 @@ struct StarWarsQueryTests {
     @Test func secretBackstoryQuery() async throws {
         let result = try await api.execute(
             request: """
-            query SecretBackstoryQuery {
-                hero {
-                    name
-                    secretBackstory
+                query SecretBackstoryQuery {
+                    hero {
+                        name
+                        secretBackstory
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "hero": [
                             "name": "R2-D2",
                             "secretBackstory": nil,
-                        ],
+                        ]
                     ],
                     errors: [
                         GraphQLError(
                             message: "secretBackstory is secret.",
                             locations: [SourceLocation(line: 4, column: 9)],
                             path: ["hero", "secretBackstory"]
-                        ),
+                        )
                     ]
                 )
         )
@@ -410,21 +410,21 @@ struct StarWarsQueryTests {
     @Test func secretBackstoryListQuery() async throws {
         let result = try await api.execute(
             request: """
-            query SecretBackstoryListQuery {
-                hero {
-                    name
-                    friends {
+                query SecretBackstoryListQuery {
+                    hero {
                         name
-                        secretBackstory
+                        friends {
+                            name
+                            secretBackstory
+                        }
                     }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "hero": [
                             "name": "R2-D2",
@@ -442,7 +442,7 @@ struct StarWarsQueryTests {
                                     "secretBackstory": nil,
                                 ],
                             ],
-                        ],
+                        ]
                     ],
                     errors: [
                         GraphQLError(
@@ -468,30 +468,30 @@ struct StarWarsQueryTests {
     @Test func secretBackstoryAliasQuery() async throws {
         let result = try await api.execute(
             request: """
-            query SecretBackstoryAliasQuery {
-                mainHero: hero {
-                    name
-                    story: secretBackstory
+                query SecretBackstoryAliasQuery {
+                    mainHero: hero {
+                        name
+                        story: secretBackstory
+                    }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "mainHero": [
                             "name": "R2-D2",
                             "story": nil,
-                        ],
+                        ]
                     ],
                     errors: [
                         GraphQLError(
                             message: "secretBackstory is secret.",
                             locations: [SourceLocation(line: 4, column: 9)],
                             path: ["mainHero", "story"]
-                        ),
+                        )
                     ]
                 )
         )
@@ -501,34 +501,34 @@ struct StarWarsQueryTests {
         let api = NonNullableFieldsAPI()
         let result = try await api.execute(
             request: """
-            query {
-                nullableA {
+                query {
                     nullableA {
-                        nonNullA {
+                        nullableA {
                             nonNullA {
-                                throws
+                                nonNullA {
+                                    throws
+                                }
                             }
                         }
                     }
                 }
-            }
-            """,
+                """,
             context: NoContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "nullableA": [
-                            "nullableA": nil,
-                        ],
+                            "nullableA": nil
+                        ]
                     ],
                     errors: [
                         GraphQLError(
                             message: "catch me if you can.",
                             locations: [SourceLocation(line: 6, column: 21)],
                             path: ["nullableA", "nullableA", "nonNullA", "nonNullA", "throws"]
-                        ),
+                        )
                     ]
                 )
         )
@@ -577,34 +577,34 @@ struct StarWarsQueryTests {
     @Test func searchQuery() async throws {
         let result = try await api.execute(
             request: """
-            query {
-                search(query: "o") {
-                    ... on Planet {
-                        name
-                        diameter
-                    }
-                    ... on Human {
-                        name
-                    }
-                    ... on Droid {
-                        name
-                        primaryFunction
+                query {
+                    search(query: "o") {
+                        ... on Planet {
+                            name
+                            diameter
+                        }
+                        ... on Human {
+                            name
+                        }
+                        ... on Droid {
+                            name
+                            primaryFunction
+                        }
                     }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "search": [
                             ["name": "Tatooine", "diameter": 10465],
                             ["name": "Han Solo"],
                             ["name": "Leia Organa"],
                             ["name": "C-3PO", "primaryFunction": "Protocol"],
-                        ],
+                        ]
                     ]
                 )
         )
@@ -613,46 +613,46 @@ struct StarWarsQueryTests {
     @Test func directive() async throws {
         var result = try await api.execute(
             request: """
-            query Hero {
-                hero {
-                    name
-
-                    friends @include(if: false) {
+                query Hero {
+                    hero {
                         name
+
+                        friends @include(if: false) {
+                            name
+                        }
                     }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "hero": [
-                            "name": "R2-D2",
-                        ],
+                            "name": "R2-D2"
+                        ]
                     ]
                 )
         )
 
         result = try await api.execute(
             request: """
-            query Hero {
-                hero {
-                    name
-
-                    friends @include(if: true) {
+                query Hero {
+                    hero {
                         name
+
+                        friends @include(if: true) {
+                            name
+                        }
                     }
                 }
-            }
-            """,
+                """,
             context: StarWarsContext()
         )
         #expect(
-            result ==
-                GraphQLResult(
+            result
+                == GraphQLResult(
                     data: [
                         "hero": [
                             "name": "R2-D2",
@@ -661,7 +661,7 @@ struct StarWarsQueryTests {
                                 ["name": "Han Solo"],
                                 ["name": "Leia Organa"],
                             ],
-                        ],
+                        ]
                     ]
                 )
         )

--- a/Tests/GraphitiTests/UnionTests.swift
+++ b/Tests/GraphitiTests/UnionTests.swift
@@ -1,7 +1,8 @@
 import Foundation
-@testable import Graphiti
 import GraphQL
 import Testing
+
+@testable import Graphiti
 
 struct UnionTests {
     @Test func unionInit() throws {
@@ -40,11 +41,14 @@ struct UnionTests {
                 Field("id", at: \.id)
             }
 
-            Union(SearchResult.self, members: [
-                Planet.self,
-                Human.self,
-                Droid.self,
-            ])
+            Union(
+                SearchResult.self,
+                members: [
+                    Planet.self,
+                    Human.self,
+                    Droid.self,
+                ]
+            )
 
             Query {
                 Field("search", at: StarWarsResolver.search) {

--- a/Tests/GraphitiTests/ValidationRulesTests.swift
+++ b/Tests/GraphitiTests/ValidationRulesTests.swift
@@ -1,7 +1,8 @@
 import Foundation
-@testable import Graphiti
 import GraphQL
 import Testing
+
+@testable import Graphiti
 
 struct ValidationRulesTests {
     /// Test registering custom validation rules
@@ -24,23 +25,24 @@ struct ValidationRulesTests {
 
         let result = try await api.execute(
             request: """
-            query {
-                __type(name: "Query") {
-                    name
-                    description
+                query {
+                    __type(name: "Query") {
+                        name
+                        description
+                    }
                 }
-            }
-            """,
+                """,
             context: NoContext(),
             validationRules: [NoIntrospectionRule]
         )
         #expect(
-            result ==
-                GraphQLResult(errors: [
+            result
+                == GraphQLResult(errors: [
                     .init(
-                        message: "GraphQL introspection is not allowed, but the query contained __schema or __type",
+                        message:
+                            "GraphQL introspection is not allowed, but the query contained __schema or __type",
                         locations: [.init(line: 2, column: 3)]
-                    ),
+                    )
                 ])
         )
     }


### PR DESCRIPTION
This changes from using https://github.com/nicklockwood/SwiftFormat to https://github.com/swiftlang/swift-format as the primary formatter. `swift-format` is the now standard formatter built into the language CLI itself, so it's easier for contributors to use.

See https://github.com/GraphQLSwift/ci/pull/6